### PR TITLE
feat: add incremental/streaming transcription support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "NVIDIA Parakeet speech recognition for the browser (WebGPU/WASM) powered by ONNX Runtime Web.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
- Add decoder state caching for incremental decode (skip prefix re-computation)

- Add _snapshotDecoderState and _restoreDecoderState helpers

- Add empty input guard to prevent ORT errors on invalid audio

- Support opts.incremental with cacheKey and prefixSeconds

- Enhance token details with raw_token and is_word_start properties

- Return is_final flag to distinguish streaming vs final results

- Bump version to 0.0.4