### PR TITLE
Expose ort globally for Silero VAD; fix max_tokens_per_step reset

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -94,6 +94,14 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
   // Store the final backend choice for use in model selection
   ort._selectedBackend = backend;
 
+  // Expose ort globally so other modules (like SileroVAD) can use the same configured instance
+  if (typeof globalThis !== 'undefined') {
+    globalThis.ort = ort;
+  }
+  if (typeof self !== 'undefined') {
+    self.ort = ort;
+  }
+
   // Return the ort module for use in creating sessions and tensors
   return ort;
 }


### PR DESCRIPTION
- backend.js: set globalThis.ort and self.ort after init for shared ONNX Runtime
- parakeet.js: reset emittedTokens on step>0, blank, or maxTokensPerStep; safety advance