### PR TITLE
fix(fromHub): flatten result.urls to top level for fromUrls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,6 @@ export async function fromHub(repoIdOrModelKey, options = {}) {
   // Resolve model key to repo ID if needed
   const repoId = MODELS[repoIdOrModelKey]?.repoId || repoIdOrModelKey;
   
-  const urls = await getParakeetModel(repoId, options);
-  return ParakeetModel.fromUrls({ ...urls, ...options });
-} 
+  const result = await getParakeetModel(repoId, options);
+  return ParakeetModel.fromUrls({ ...result.urls, filenames: result.filenames, ...options });
+}

--- a/test_webgpu_simple.js
+++ b/test_webgpu_simple.js
@@ -21,19 +21,20 @@ async function testBackend() {
     console.log('3. Testing Hub integration...');
     const { getParakeetModel } = await import('./src/hub.js');
     
-    const modelUrls = await getParakeetModel('istupakov/parakeet-tdt-0.6b-v2-onnx', { 
+    const result = await getParakeetModel('istupakov/parakeet-tdt-0.6b-v2-onnx', { 
       quantization: 'int8',
       preprocessor: 'nemo128'
     });
     
-    console.log('✓ Model URLs retrieved:', Object.keys(modelUrls));
+    console.log('✓ Model URLs retrieved:', Object.keys(result.urls));
     
     // Test 4: Try to create a model instance
     console.log('4. Testing model creation...');
     const { ParakeetModel } = await import('./src/parakeet.js');
     
     const model = await ParakeetModel.fromUrls({
-      ...modelUrls,
+      ...result.urls,
+      filenames: result.filenames,
       backend: 'webgpu'
     });
     
@@ -45,4 +46,4 @@ async function testBackend() {
   }
 }
 
-testBackend(); 
+testBackend();


### PR DESCRIPTION
getParakeetModel() returns { urls: { encoderUrl, ... }, filenames, ... } but fromHub was spreading the entire result object, leaving URLs nested.

This caused fromUrls() to fail with:
"fromUrls requires encoderUrl, decoderUrl, tokenizerUrl and preprocessorUrl"

Also fixes the same pattern in test_webgpu_simple.js.