### PR TITLE
Clean up outdated TODO comment in ParakeetModel

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -7,8 +7,6 @@ import { JsPreprocessor, IncrementalMelProcessor } from './mel.js';
  * Lightweight Parakeet model wrapper designed for browser usage.
  * Currently supports the *combined* decoder_joint-model ONNX (encoder+decoder+joiner in '
  * transformerjs' style) exported by parakeet TDT.
- *
- * NOTE: This is an *early* scaffold – the `transcribe` method is TODO.
  */
 export class ParakeetModel {
   constructor({ tokenizer, encoderSession, joinerSession, preprocessor, ort, subsampling = 8, windowStride = 0.01, normalizer = (s) => s, onnxPreprocessor = null, nMels }) {


### PR DESCRIPTION
Removed the outdated JSDoc comment in `src/parakeet.js` that stated the `transcribe` method was TODO. The method is fully implemented and tested. This improves code health by keeping documentation up-to-date.

---
*PR created automatically by Jules for task [13957050997344201347](https://jules.google.com/task/13957050997344201347) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comment with no impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->