### PR TITLE
Remove redundant self.ort assignment

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -99,9 +99,6 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
   if (typeof globalThis !== 'undefined') {
     globalThis.ort = ort;
   }
-  if (typeof self !== 'undefined') {
-    self.ort = ort;
-  }
 
   // Return the ort module for use in creating sessions and tensors
   return ort;


### PR DESCRIPTION
Removed the redundant `self.ort` assignment in `src/backend.js` as `globalThis.ort` is sufficient. This simplifies the code and aligns with modern JS practices. Verified by running tests.

---
*PR created automatically by Jules for task [12174266680745745899](https://jules.google.com/task/12174266680745745899) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal optimization with no impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->