### PR TITLE
Refactor src/index.js dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parakeet.js",
-  "version": "1.0.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parakeet.js",
-      "version": "1.0.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+import { ParakeetModel } from './parakeet.js';
+import { getParakeetModel } from './hub.js';
+import { MODELS } from './models.js';
+
 export { ParakeetModel, StatefulStreamingTranscriber, FrameAlignedMerger, LCSPTFAMerger } from './parakeet.js';
 export { getModelFile, getModelText, getParakeetModel } from './hub.js';
 export { MODELS, LANGUAGE_NAMES, DEFAULT_MODEL, getModelConfig, getModelKeyFromRepoId, supportsLanguage, listModels, getLanguageName } from './models.js';
@@ -11,7 +15,6 @@ export { JsPreprocessor, IncrementalMelProcessor, MEL_CONSTANTS, hzToMel, melToH
  * const model = await fromUrls({ ... });
  */
 export async function fromUrls(cfg) {
-  const { ParakeetModel } = await import('./parakeet.js');
   return ParakeetModel.fromUrls(cfg);
 }
 
@@ -26,10 +29,6 @@ export async function fromUrls(cfg) {
  * const model = await fromHub('parakeet-tdt-0.6b-v3', { quantization: 'int8' });
  */
 export async function fromHub(repoIdOrModelKey, options = {}) {
-  const { getParakeetModel } = await import('./hub.js');
-  const { ParakeetModel } = await import('./parakeet.js');
-  const { MODELS } = await import('./models.js');
-
   // Resolve model key to repo ID if needed
   const repoId = MODELS[repoIdOrModelKey]?.repoId || repoIdOrModelKey;
 

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fromUrls, fromHub } from '../src/index.js';
+import { ParakeetModel } from '../src/parakeet.js';
+import { getParakeetModel } from '../src/hub.js';
+
+vi.mock('../src/parakeet.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    ParakeetModel: {
+      fromUrls: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../src/hub.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getParakeetModel: vi.fn(),
+  };
+});
+
+describe('index.js', () => {
+  it('fromUrls should call ParakeetModel.fromUrls', async () => {
+    const cfg = { some: 'config' };
+    await fromUrls(cfg);
+    expect(ParakeetModel.fromUrls).toHaveBeenCalledWith(cfg);
+  });
+
+  it('fromHub should call getParakeetModel and ParakeetModel.fromUrls', async () => {
+    const repoId = 'some-repo';
+    const options = { opt: 'val' };
+    const mockModelData = {
+      urls: { u: 1 },
+      filenames: { f: 1 },
+      preprocessorBackend: 'js'
+    };
+
+    getParakeetModel.mockResolvedValue(mockModelData);
+
+    await fromHub(repoId, options);
+
+    expect(getParakeetModel).toHaveBeenCalledWith(repoId, options);
+    expect(ParakeetModel.fromUrls).toHaveBeenCalledWith({
+      ...mockModelData.urls,
+      filenames: mockModelData.filenames,
+      preprocessorBackend: mockModelData.preprocessorBackend,
+      ...options,
+    });
+  });
+});


### PR DESCRIPTION
Refactored `src/index.js` to use static top-level imports for `ParakeetModel`, `getParakeetModel`, and `MODELS` instead of dynamic imports inside `fromUrls` and `fromHub`. This improves code readability and static analysis compatibility. Also added `tests/index.test.mjs` to verify functionality.

---
*PR created automatically by Jules for task [4063224163951053442](https://jules.google.com/task/4063224163951053442) started by @ysdede*