### PR TITLE
Make performance logging conditional in transcribe

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -457,6 +457,7 @@ export class ParakeetModel {
       returnConfidences = false,
       temperature = 1.0, // Greedy decoding (1.0) is better for ASR than sampling (1.2)
       debug = false,
+      enableProfiling = false,
       skipCMVN = false,
       frameStride = 1,
       // NEW: Streaming options
@@ -474,7 +475,7 @@ export class ParakeetModel {
       precomputedFeatures = null,    // { features: Float32Array, T: number, melBins: number }
     } = opts;
 
-    const perfEnabled = true; // always collect and log timings
+    const perfEnabled = debug || enableProfiling; // collect and log timings
     let t0, tPreproc = 0, tEncode = 0, tDecode = 0, tToken = 0;
     if (perfEnabled) t0 = performance.now();
 

--- a/tests/transcribe_perf.test.mjs
+++ b/tests/transcribe_perf.test.mjs
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ParakeetModel } from '../src/parakeet.js';
+
+describe('ParakeetModel.transcribe performance logging', () => {
+  const mockOrt = {
+    Tensor: class {
+      constructor(type, data, dims) {
+        this.type = type;
+        this.data = data;
+        this.dims = dims;
+      }
+    }
+  };
+
+  const mockTokenizer = {
+    blankId: 0,
+    id2token: ['<blank>', 'a', 'b', 'c', '<unk>', '▁foo', '▁bar'], // dummy tokens
+    blankToken: '<blank>',
+    decode: (ids) => ids.map(id => mockTokenizer.id2token[id]).join(''),
+  };
+
+  const mockEncoderSession = {
+    run: vi.fn().mockResolvedValue({ outputs: { dims: [1, 64, 10], data: new Float32Array(640) } }),
+  };
+
+  const mockJoinerSession = {
+    run: vi.fn().mockResolvedValue({
+        outputs: { dims: [1, 1, 1, 10], data: new Float32Array(10) }, // logits
+        output_states_1: { dims: [2, 1, 640], data: new Float32Array(1280) },
+        output_states_2: { dims: [2, 1, 640], data: new Float32Array(1280) },
+    }),
+  };
+
+  const mockPreprocessor = {
+    process: vi.fn().mockResolvedValue({ features: new Float32Array(1280), length: 10 }), // 10 frames, 128 bins
+  };
+
+  const model = new ParakeetModel({
+    tokenizer: mockTokenizer,
+    encoderSession: mockEncoderSession,
+    joinerSession: mockJoinerSession,
+    preprocessor: mockPreprocessor,
+    ort: mockOrt,
+    nMels: 128,
+  });
+
+  it('should NOT return metrics by default (metrics should be null)', async () => {
+    const result = await model.transcribe(new Float32Array(16000), 16000, {});
+    expect(result.metrics).toBeNull();
+  });
+
+  it('should return metrics when enableProfiling is true', async () => {
+    const result = await model.transcribe(new Float32Array(16000), 16000, { enableProfiling: true });
+    expect(result.metrics).not.toBeNull();
+    expect(result.metrics).toHaveProperty('total_ms');
+  });
+
+  it('should return metrics when debug is true', async () => {
+    const result = await model.transcribe(new Float32Array(16000), 16000, { debug: true });
+    expect(result.metrics).not.toBeNull();
+    expect(result.metrics).toHaveProperty('total_ms');
+  });
+});


### PR DESCRIPTION
This change makes performance logging and metrics collection in `ParakeetModel.transcribe` conditional, instead of being hardcoded to `true`.

It introduces an `enableProfiling` option to `transcribe`. Performance metrics are now collected only if `debug` or `enableProfiling` is true.

This prevents unnecessary `performance.now()` calls and console spam in production usage, while allowing developers to opt-in for debugging and profiling.

Verification:
- Added `tests/transcribe_perf.test.mjs` which confirms:
  - Metrics are null by default.
  - Metrics are present when `enableProfiling: true`.
  - Metrics are present when `debug: true`.
- Ran full test suite (`npm test`) to ensure no regressions.


---
*PR created automatically by Jules for task [16612663042696932520](https://jules.google.com/task/16612663042696932520) started by @ysdede*