### PR TITLE
Refactor IncrementalMelProcessor.clear to alias reset

### DIFF
--- a/src/mel.js
+++ b/src/mel.js
@@ -596,10 +596,7 @@ export class IncrementalMelProcessor {
    * Clear the cache (e.g., on recording restart).
    */
   clear() {
-    this._cachedRawMel = null;
-    this._cachedNFrames = 0;
-    this._cachedAudioLen = 0;
-    this._cachedFeaturesLen = 0;
+    this.reset();
   }
 }
 

--- a/tests/mel.test.mjs
+++ b/tests/mel.test.mjs
@@ -432,12 +432,17 @@ describe('IncrementalMelProcessor', () => {
     const audio = new Float32Array(16000);
     for (let i = 0; i < audio.length; i++) audio[i] = Math.sin(2 * Math.PI * 440 * i / 16000);
 
+    // Test clear()
     inc.process(audio, 0);
     inc.clear();
-
-    // After clear, second call should NOT be cached
     const r2 = inc.process(audio, 0);
     expect(r2.cached).toBe(false);
+
+    // Test reset()
+    inc.process(audio, 0);
+    inc.reset();
+    const r3 = inc.process(audio, 0);
+    expect(r3.cached).toBe(false);
   });
 });
 


### PR DESCRIPTION
🎯 **What:** Consolidated `IncrementalMelProcessor.clear()` to be an alias for `reset()`.
💡 **Why:** Reduces code duplication and improves API clarity, as both methods are intended to clear the cache.
✅ **Verification:** Updated `tests/mel.test.mjs` to verify both `clear()` and `reset()` correctly clear the cache. Ran `npm test tests/mel.test.mjs` and all tests passed.
✨ **Result:** Cleaner code in `src/mel.js` with maintained functionality.

---
*PR created automatically by Jules for task [10933334767208603949](https://jules.google.com/task/10933334767208603949) started by @ysdede*