### PR TITLE
Optimize inefficient array slicing in decoding loop

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -268,8 +268,8 @@ export class ParakeetModel {
     const totalDim = logits.dims[3];
     const data = logits.data;
 
-    const tokenLogits = data.slice(0, vocab);
-    const durLogits = data.slice(vocab, totalDim);
+    const tokenLogits = data.subarray(0, vocab);
+    const durLogits = data.subarray(vocab, totalDim);
 
     let step = 0;
     if (durLogits.length) {

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -268,6 +268,8 @@ export class ParakeetModel {
     const totalDim = logits.dims[3];
     const data = logits.data;
 
+    // Optimization: subarray returns a view on the existing buffer (zero-copy).
+    // CAUTION: These are read-only views. Mutating them will corrupt the original logits.data buffer.
     const tokenLogits = data.subarray(0, vocab);
     const durLogits = data.subarray(vocab, totalDim);
 


### PR DESCRIPTION
Replaced `slice` with `subarray` in `src/parakeet.js` to avoid memory allocation and copying overhead.
Measured significant performance improvement in micro-benchmark.
Verified existing tests pass.

---
*PR created automatically by Jules for task [9643704293746588552](https://jules.google.com/task/9643704293746588552) started by @ysdede*