### PR TITLE
Optimize mel filterbank application

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Mel Filterbank Sparsity
+**Learning:** The Slaney mel filterbank used in speech processing is ~98.5% sparse (mostly zeros).
+**Action:** When implementing matrix multiplications involving filterbanks, always check for sparsity and precompute non-zero bounds to skip redundant zero-multiplications.


### PR DESCRIPTION
💡 **What**: Precompute start/end indices for sparse mel filterbank matrix multiplication.
🎯 **Why**: The mel filterbank is ~98.5% sparse (mostly zeros). Iterating over all 257 frequency bins for each of the 80/128 mel bins is wasteful.
📊 **Impact**: Reduces 5s audio processing time from ~86ms to ~31ms (~2.7x speedup).
🔬 **Measurement**: Verified with `bench_mel.js` and existing `tests/mel.test.mjs`.

---
*PR created automatically by Jules for task [11898680466531458957](https://jules.google.com/task/11898680466531458957) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized mel filterbank processing by skipping redundant zero-multiplication operations, leveraging sparsity patterns in audio preprocessing for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->