### PR TITLE
Optimize mel filterbank matmul

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Sparse Matrix Optimization]
+**Learning:** The Slaney Mel filterbank is extremely sparse (~98.5% zeros). A naive implementation iterates `nMels * N_FREQ_BINS` (128 * 257 = 32,896) times per frame. By precomputing the start/end indices of non-zero values, we reduced the inner loop iterations to ~12 per mel bin, yielding a ~4.5x overall speedup for `JsPreprocessor` (77ms -> 17ms for 5s audio).
+**Action:** Always check for sparsity in matrix operations, especially with filterbanks or kernels that have localized support.


### PR DESCRIPTION
💡 **What**: Optimized the application of the Mel filterbank in `JsPreprocessor` by pre-calculating the start and end indices of non-zero coefficients for each Mel bin.
🎯 **Why**: The Mel filterbank matrix is extremely sparse (~98.5% zeros). Iterating over all frequency bins (257) for each Mel bin (128) wasted CPU cycles on zero multiplications.
📊 **Impact**:
- Reduces inner loop iterations from 257 to ~12 (avg) per mel bin.
- **4.5x speedup** for `computeRawMel` on 5s of audio (77ms -> 17ms).
- Frees up CPU time for the actual inference in streaming scenarios.
🔬 **Measurement**:
- Validated numerical correctness against baseline (max diff: 0).
- Validated against ONNX reference implementation (existing tests passed).
- Benchmarked with 5s random audio input.

---
*PR created automatically by Jules for task [12144756719088363647](https://jules.google.com/task/12144756719088363647) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on matrix operation optimization techniques.

* **Refactor**
  * Improved audio preprocessing performance, achieving ~4.5x speedup (17ms vs 77ms for 5-second audio).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->