### PR TITLE
feat(types): publish bundled declaration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ yarn add parakeet.js
 
 TypeScript users:
 - The package ships bundled declarations via the top-level `"types"` field.
-- Subpath declaration resolution via `exports.types` works in newer TypeScript releases (for example TS 5.x). If your toolchain is older, use the root import (`parakeet.js`) or upgrade TypeScript.
+- Subpath declaration resolution via `exports.types` works in TS 4.7+ when `moduleResolution` is `node16`, `nodenext`, or `bundler`. If your toolchain is older, use the root import (`parakeet.js`) or upgrade TypeScript.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ yarn add parakeet.js
 
 `onnxruntime-web` is bundled as a dependency and supplies the runtime back-ends (WebGPU, WASM).
 
+TypeScript users:
+- The package ships bundled declarations via the top-level `"types"` field.
+- Subpath declaration resolution via `exports.types` works in newer TypeScript releases (for example TS 5.x). If your toolchain is older, use the root import (`parakeet.js`) or upgrade TypeScript.
+
 ---
 
 ## Model assets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parakeet.js",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parakeet.js",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "onnxruntime-web": "1.24.1"

--- a/package.json
+++ b/package.json
@@ -3,15 +3,32 @@
   "version": "1.2.1",
   "description": "NVIDIA Parakeet speech recognition for the browser (WebGPU/WASM) powered by ONNX Runtime Web.",
   "type": "module",
+  "types": "./types/index.d.ts",
   "exports": {
-    ".": "./src/index.js",
-    "./parakeet": "./src/parakeet.js",
-    "./hub": "./src/hub.js",
-    "./models": "./src/models.js",
-    "./mel": "./src/mel.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./parakeet": {
+      "types": "./types/parakeet.d.ts",
+      "default": "./src/parakeet.js"
+    },
+    "./hub": {
+      "types": "./types/hub.d.ts",
+      "default": "./src/hub.js"
+    },
+    "./models": {
+      "types": "./types/models.d.ts",
+      "default": "./src/models.js"
+    },
+    "./mel": {
+      "types": "./types/mel.d.ts",
+      "default": "./src/mel.js"
+    }
   },
   "files": [
     "src",
+    "types",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "NVIDIA Parakeet speech recognition for the browser (WebGPU/WASM) powered by ONNX Runtime Web.",
   "type": "module",
   "types": "./types/index.d.ts",

--- a/types/hub.d.ts
+++ b/types/hub.d.ts
@@ -1,0 +1,49 @@
+import type { BackendMode, PreprocessorBackend } from './parakeet';
+import type { ModelConfig } from './models';
+
+export interface HubProgress {
+  loaded: number;
+  total: number;
+  file: string;
+}
+
+export interface GetModelFileOptions {
+  revision?: string;
+  subfolder?: string;
+  progress?: (progress: HubProgress) => void;
+}
+
+export interface GetParakeetModelOptions {
+  revision?: string;
+  encoderQuant?: 'int8' | 'fp32';
+  decoderQuant?: 'int8' | 'fp32';
+  preprocessor?: 'nemo80' | 'nemo128';
+  preprocessorBackend?: PreprocessorBackend;
+  backend?: BackendMode;
+  progress?: (progress: HubProgress) => void;
+}
+
+export interface GetParakeetModelResult {
+  urls: {
+    encoderUrl: string;
+    decoderUrl: string;
+    tokenizerUrl: string;
+    preprocessorUrl?: string;
+    encoderDataUrl?: string | null;
+    decoderDataUrl?: string | null;
+  };
+  filenames: {
+    encoder: string;
+    decoder: string;
+  };
+  quantisation: {
+    encoder: 'int8' | 'fp32';
+    decoder: 'int8' | 'fp32';
+  };
+  modelConfig: ModelConfig | null;
+  preprocessorBackend: PreprocessorBackend;
+}
+
+export function getModelFile(repoId: string, filename: string, options?: GetModelFileOptions): Promise<string>;
+export function getModelText(repoId: string, filename: string, options?: GetModelFileOptions): Promise<string>;
+export function getParakeetModel(repoIdOrModelKey: string, options?: GetParakeetModelOptions): Promise<GetParakeetModelResult>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,38 @@
-export * from './parakeet';
-export * from './hub';
-export * from './models';
-export * from './mel';
+export {
+  ParakeetModel,
+  StatefulStreamingTranscriber,
+  FrameAlignedMerger,
+  LCSPTFAMerger,
+} from './parakeet';
+
+export {
+  getModelFile,
+  getModelText,
+  getParakeetModel,
+} from './hub';
+
+export {
+  MODELS,
+  LANGUAGE_NAMES,
+  DEFAULT_MODEL,
+  getModelConfig,
+  getModelKeyFromRepoId,
+  supportsLanguage,
+  listModels,
+  getLanguageName,
+} from './models';
+
+export {
+  JsPreprocessor,
+  IncrementalMelProcessor,
+  MEL_CONSTANTS,
+  hzToMel,
+  melToHz,
+  createMelFilterbank,
+  createPaddedHannWindow,
+  precomputeTwiddles,
+  fft,
+} from './mel';
 
 import type { FromUrlsConfig, ParakeetModel } from './parakeet';
 import type { GetParakeetModelOptions } from './hub';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,10 @@
+export * from './parakeet';
+export * from './hub';
+export * from './models';
+export * from './mel';
+
+import type { FromUrlsConfig, ParakeetModel } from './parakeet';
+import type { GetParakeetModelOptions } from './hub';
+
+export function fromUrls(cfg: FromUrlsConfig): Promise<ParakeetModel>;
+export function fromHub(repoIdOrModelKey: string, options?: GetParakeetModelOptions): Promise<ParakeetModel>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,5 +37,18 @@ export {
 import type { FromUrlsConfig, ParakeetModel } from './parakeet';
 import type { GetParakeetModelOptions } from './hub';
 
+export type {
+  TranscribeResult,
+  TranscribeOptions,
+  FromUrlsConfig,
+} from './parakeet';
+
+export type { ModelConfig } from './models';
+export type { GetParakeetModelOptions } from './hub';
+
+export type FromHubOptions =
+  GetParakeetModelOptions &
+  Partial<Pick<FromUrlsConfig, 'cpuThreads' | 'wasmPaths' | 'enableGraphCapture' | 'verbose' | 'subsampling' | 'windowStride' | 'enableProfiling' | 'nMels'>>;
+
 export function fromUrls(cfg: FromUrlsConfig): Promise<ParakeetModel>;
-export function fromHub(repoIdOrModelKey: string, options?: GetParakeetModelOptions): Promise<ParakeetModel>;
+export function fromHub(repoIdOrModelKey: string, options?: FromHubOptions): Promise<ParakeetModel>;

--- a/types/mel.d.ts
+++ b/types/mel.d.ts
@@ -1,0 +1,38 @@
+export declare const MEL_CONSTANTS: {
+  SAMPLE_RATE: number;
+  N_FFT: number;
+  WIN_LENGTH: number;
+  HOP_LENGTH: number;
+  PREEMPH: number;
+  LOG_ZERO_GUARD: number;
+  N_FREQ_BINS: number;
+};
+
+export function hzToMel(freq: number): number;
+export function melToHz(mel: number): number;
+export function createMelFilterbank(nMels: number): Float32Array;
+export function createPaddedHannWindow(): Float64Array;
+export function precomputeTwiddles(N: number): { cos: Float64Array; sin: Float64Array };
+export function fft(re: Float64Array, im: Float64Array, N: number, tw: { cos: Float64Array; sin: Float64Array }): void;
+
+export class JsPreprocessor {
+  readonly nMels: number;
+  constructor(opts?: { nMels?: number });
+  process(audio: Float32Array): { features: Float32Array; length: number };
+  computeRawMel(audio: Float32Array, startFrame?: number): { rawMel: Float32Array; nFrames: number; featuresLen: number };
+  normalizeFeatures(rawMel: Float32Array, nFrames: number, featuresLen: number): Float32Array;
+}
+
+export class IncrementalMelProcessor {
+  readonly nMels: number;
+  constructor(opts?: { nMels?: number; boundaryFrames?: number });
+  reset(): void;
+  process(audio: Float32Array, prefixSamples?: number): {
+    features: Float32Array;
+    length: number;
+    cached: boolean;
+    cachedFrames: number;
+    newFrames: number;
+  };
+  clear(): void;
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -1,0 +1,22 @@
+export interface ModelConfig {
+  repoId: string;
+  displayName: string;
+  languages: string[];
+  defaultLanguage: string;
+  vocabSize: number;
+  featuresSize: number;
+  preprocessor: string;
+  subsampling: number;
+  predHidden: number;
+  predLayers: number;
+}
+
+export declare const LANGUAGE_NAMES: Record<string, string>;
+export declare const MODELS: Record<string, ModelConfig>;
+export declare const DEFAULT_MODEL: string;
+
+export function getModelConfig(modelKeyOrRepoId: string): ModelConfig | null;
+export function getModelKeyFromRepoId(repoId: string): string | null;
+export function supportsLanguage(modelKeyOrRepoId: string, language: string): boolean;
+export function listModels(): string[];
+export function getLanguageName(langCode: string): string;

--- a/types/parakeet.d.ts
+++ b/types/parakeet.d.ts
@@ -1,0 +1,219 @@
+export type BackendMode = 'webgpu' | 'webgpu-hybrid' | 'webgpu-strict' | 'wasm';
+export type PreprocessorBackend = 'js' | 'onnx';
+
+export interface DecoderStateSnapshot {
+  s1: Float32Array;
+  s2: Float32Array;
+  dims1: number[];
+  dims2: number[];
+}
+
+export interface ComputeFeaturesResult {
+  features: Float32Array;
+  T: number;
+  melBins: number;
+  validLength?: number;
+  cached?: boolean;
+  cachedFrames?: number;
+  newFrames?: number;
+}
+
+export interface PrecomputedFeatures {
+  features: Float32Array;
+  T: number;
+  melBins: number;
+}
+
+export interface TranscribeOptions {
+  returnTimestamps?: boolean;
+  returnConfidences?: boolean;
+  temperature?: number;
+  debug?: boolean;
+  enableProfiling?: boolean;
+  skipCMVN?: boolean;
+  frameStride?: number;
+  previousDecoderState?: DecoderStateSnapshot | null;
+  returnDecoderState?: boolean;
+  timeOffset?: number;
+  returnTokenIds?: boolean;
+  returnFrameIndices?: boolean;
+  returnLogProbs?: boolean;
+  returnTdtSteps?: boolean;
+  prefixSamples?: number;
+  precomputedFeatures?: PrecomputedFeatures | null;
+  incremental?: {
+    cacheKey: string;
+    prefixSeconds: number;
+  } | null;
+}
+
+export interface TranscribeWord {
+  text: string;
+  start_time: number;
+  end_time: number;
+  confidence?: number;
+}
+
+export interface TranscribeToken {
+  token: string;
+  start_time: number;
+  end_time: number;
+  confidence?: number;
+}
+
+export interface TranscribeResult {
+  utterance_text: string;
+  words: TranscribeWord[];
+  tokens: TranscribeToken[];
+  confidence_scores?: Record<string, number | null>;
+  metrics?: {
+    preprocess_ms: number;
+    encode_ms: number;
+    decode_ms: number;
+    tokenize_ms: number;
+    total_ms: number;
+    rtf: number;
+    mel_cache?: { cached_frames: number; new_frames: number };
+  } | null;
+  is_final: boolean;
+  decoderState?: DecoderStateSnapshot;
+  tokenIds?: number[];
+  frameIndices?: number[];
+  logProbs?: number[];
+  tdtSteps?: number[];
+}
+
+export interface FromUrlsConfig {
+  encoderUrl: string;
+  decoderUrl: string;
+  tokenizerUrl: string;
+  preprocessorUrl?: string;
+  encoderDataUrl?: string | null;
+  decoderDataUrl?: string | null;
+  filenames?: { encoder: string; decoder: string };
+  backend?: BackendMode;
+  wasmPaths?: string;
+  subsampling?: number;
+  windowStride?: number;
+  verbose?: boolean;
+  enableProfiling?: boolean;
+  enableGraphCapture?: boolean;
+  cpuThreads?: number;
+  preprocessorBackend?: PreprocessorBackend;
+  nMels?: number;
+}
+
+export interface StreamingTranscriberOptions {
+  returnTimestamps?: boolean;
+  returnConfidences?: boolean;
+  returnTokenIds?: boolean;
+  sampleRate?: number;
+  debug?: boolean;
+}
+
+export class ParakeetModel {
+  static fromUrls(cfg: FromUrlsConfig): Promise<ParakeetModel>;
+  computeFeatures(audio: Float32Array, sampleRate?: number, opts?: { prefixSamples?: number }): Promise<ComputeFeaturesResult>;
+  setPreprocessorBackend(backend: PreprocessorBackend): void;
+  getPreprocessorBackend(): PreprocessorBackend;
+  resetMelCache(): void;
+  clearIncrementalCache(): void;
+  getFrameTimeStride(): number;
+  frameToTime(frameIndex: number, timeOffset?: number): number;
+  getStreamingConstants(): {
+    subsampling: number;
+    windowStride: number;
+    frameTimeStride: number;
+    melBins: number;
+    blankId: number;
+    maxTokensPerStep: number;
+  };
+  transcribe(audio: Float32Array | null, sampleRate?: number, opts?: TranscribeOptions): Promise<TranscribeResult>;
+  createStreamingTranscriber(opts?: StreamingTranscriberOptions): StatefulStreamingTranscriber;
+  endProfiling(): Record<string, { gpu_us: number; cpu_us: number; total_us: number }> | null;
+}
+
+export class StatefulStreamingTranscriber {
+  constructor(model: ParakeetModel, opts?: StreamingTranscriberOptions);
+  processChunk(audio: Float32Array): Promise<{
+    chunkText: string;
+    chunkWords: TranscribeWord[];
+    text: string;
+    words: TranscribeWord[];
+    totalDuration: number;
+    chunkCount: number;
+    is_final: boolean;
+    tokenIds?: number[];
+    confidence_scores?: Record<string, number | null>;
+    metrics?: TranscribeResult['metrics'];
+  }>;
+  finalize(): {
+    text: string;
+    words: TranscribeWord[];
+    totalDuration: number;
+    chunkCount: number;
+    is_final: boolean;
+    tokenIds?: number[];
+  };
+  reset(): void;
+  getState(): {
+    hasDecoderState: boolean;
+    currentOffset: number;
+    wordCount: number;
+    chunkCount: number;
+    isFinalized: boolean;
+  };
+}
+
+export class MelFeatureCache {
+  constructor(opts?: { maxCacheSizeMB?: number });
+  getFeatures(model: ParakeetModel, audio: Float32Array): Promise<{ features: Float32Array; T: number; melBins: number; cached: boolean }>;
+  clear(): void;
+  getStats(): { entries: number; sizeMB: string; maxSizeMB: number };
+}
+
+export class FrameAlignedMerger {
+  constructor(opts?: { frameTimeStride?: number; timeTolerance?: number; stabilityThreshold?: number });
+  processChunk(result: {
+    tokenIds: number[];
+    frameIndices: number[];
+    timestamps?: number[][];
+    logProbs?: number[];
+    tokens?: Array<{ token?: string }>;
+  }, chunkStartTime: number, overlapDuration?: number): {
+    confirmed: Array<Record<string, unknown>>;
+    pending: Array<Record<string, unknown>>;
+    anchorsFound: number;
+    totalTokens: number;
+  };
+  getText(tokenizer: { decode(ids: number[]): string }): string;
+  getAllTokens(): Array<Record<string, unknown>>;
+  reset(): void;
+  getState(): { confirmedCount: number; pendingCount: number; stabilityMapSize: number };
+}
+
+export class LCSPTFAMerger {
+  constructor(opts?: { frameTimeStride?: number; timeTolerance?: number; sequenceAnchorLength?: number; vignetteSigmaFactor?: number });
+  processChunk(result: {
+    tokenIds: number[];
+    frameIndices: number[];
+    logProbs?: number[];
+    tokens?: Array<{ token?: string }>;
+  }, chunkStartTime: number, overlapDuration?: number): {
+    confirmed: Array<Record<string, unknown>>;
+    pending: Array<Record<string, unknown>>;
+    lcsLength: number;
+    anchorValid: boolean;
+    overlapTokenCount?: number;
+    isFirstChunk?: boolean;
+  };
+  getText(tokenizer: { decode(ids: number[]): string }): { confirmed: string; pending: string; full: string };
+  getAllTokens(): Array<Record<string, unknown>>;
+  reset(): void;
+  getState(): {
+    confirmedCount: number;
+    pendingCount: number;
+    lastConfirmedTime: number;
+    lastPendingTime: number;
+  };
+}

--- a/types/parakeet.d.ts
+++ b/types/parakeet.d.ts
@@ -58,8 +58,8 @@ export interface TranscribeToken {
   token: string;
   raw_token?: string;
   is_word_start?: boolean;
-  start_time: number;
-  end_time: number;
+  start_time?: number;
+  end_time?: number;
   confidence?: number;
 }
 
@@ -166,7 +166,7 @@ export class StatefulStreamingTranscriber {
     chunkCount: number;
     is_final: boolean;
     tokenIds?: number[];
-    confidence_scores?: Record<string, number | null>;
+    confidence_scores?: TranscribeConfidenceScores;
     metrics?: TranscribeResult['metrics'];
   }>;
   finalize(): {

--- a/types/parakeet.d.ts
+++ b/types/parakeet.d.ts
@@ -74,6 +74,10 @@ export interface TranscribeConfidenceScoresDetailed {
 }
 
 export interface TranscribeConfidenceScoresMinimal {
+  token?: null;
+  token_avg?: null;
+  word?: null;
+  word_avg?: null;
   overall_log_prob: null;
   frame: null;
   frame_avg: null;


### PR DESCRIPTION
Summary
- add shipped declaration files under `types/` for root and public subpaths
- wire package metadata so TypeScript resolves declarations from the package itself
- include `types/` in publish files

Changes
- `package.json`
  - add `types: "./types/index.d.ts"`
  - add `types` condition for exports: `.`, `./parakeet`, `./hub`, `./models`, `./mel`
  - include `types` in `files`
- new files:
  - `types/index.d.ts`
  - `types/parakeet.d.ts`
  - `types/hub.d.ts`
  - `types/models.d.ts`
  - `types/mel.d.ts`

Validation
- `npm pack --dry-run` includes all `types/*.d.ts` files
- `npm exec --yes --package typescript tsc -- --noEmit --skipLibCheck --moduleResolution bundler --module esnext --target es2020 types/index.d.ts` passes

This removes the need for downstream local shims like `src/parakeet-js.d.ts` once released.