### PR TITLE
docs: refactor README and add published TypeDoc API reference

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: examples/demo/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            examples/demo/package-lock.json
 
       - name: Install root dependencies for local source build
         run: npm install

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'examples/demo/**'
       - 'src/**'
+      - 'types/**'
+      - 'README.md'
+      - 'typedoc.json'
       - 'package.json'
       - '.github/workflows/deploy-gh-pages.yml'
   workflow_dispatch:  # Allow manual trigger
@@ -33,6 +36,9 @@ jobs:
       - name: Install root dependencies for local source build
         run: npm install
 
+      - name: Build API docs
+        run: npm run docs:api
+
       - name: Use local parakeet.js package for demo build
         working-directory: examples/demo
         run: |
@@ -59,6 +65,9 @@ jobs:
           
           # Copy built assets
           cp -r examples/demo/dist/* deploy_temp/
+
+          # Copy generated TypeDoc site under /api
+          cp -r .typedoc-site deploy_temp/api
           
           # Add .nojekyll to prevent Jekyll processing
           touch deploy_temp/.nojekyll

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ dist/
 # Documentation and Scripts
 docs/
 scripts/
+.typedoc-site/
 
 # Internal
 *OPTIMIZATION*.md
 audio/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,564 +1,181 @@
 # Parakeet.js
 
-[Keet Live Streaming](https://ysdede.github.io/keet/) | [Live Demo](https://ysdede.github.io/parakeet.js/) | [NPM Package](https://www.npmjs.com/package/parakeet.js)
+[Live Demo](https://ysdede.github.io/parakeet.js/) | [Keet](https://ysdede.github.io/keet/) | [NPM Package](https://www.npmjs.com/package/parakeet.js)
 
-<a href="https://ysdede.github.io/keet/" target="_blank" rel="noopener noreferrer">
-  <img src="https://raw.githubusercontent.com/ysdede/keet/refs/heads/master/public/img/streaming-preview.jpg" alt="Real-time transcription with Parakeet.js" />
-</a>
+## What is parakeet.js
 
-Browser-based speech-to-text using NVIDIA Parakeet models. Runs entirely client-side on **WebGPU** or **WASM** via [ONNX Runtime Web](https://onnxruntime.ai/).
-
-**Key features:**
-- Pure JavaScript mel spectrogram preprocessor with incremental caching for real-time streaming
-- Parallel preprocessing support via worker threads and `precomputedFeatures` direct-feed path
-- Stateful chunked inference with cached decoder state for low-latency applications
-
-### Features in detail
-
-- **Decoder state caching and reuse**: Incremental decoder cache stores LSTM state at the prefix boundary (keyed by `cacheKey`); the next call with the same key restores state and skips decoding the overlapping prefix (~80% decoder time savings for typical overlap). Chunk-to-chunk streaming uses `previousDecoderState` / `returnDecoderState` with snapshot/restore so decoding continues without redoing the past. `StatefulStreamingTranscriber` uses this flow internally.
-- **Mel and feature caching**: `IncrementalMelProcessor` caches raw mel frames. With `prefixSamples` only new frames are computed; the rest are reused (~60-70% preprocessing savings for overlapping streaming). Metrics can report `mel_cache: { cached_frames, new_frames }`.
-- **Decoding speedups**: Zero-copy `subarray()` instead of `slice()` for token and duration logits in the hot path; systematic tensor disposal to avoid WASM/GPU growth; pre-allocated tensors for target, length, and encoder frame.
-- **Preprocessor in a separate worker**: The library accepts precomputed mel features via `precomputedFeatures`. When your app runs mel in its own worker and passes that in, `transcribe()` skips built-in preprocessing (0 ms preprocessing in the main thread) and you get pipeline parallelism: mel in one worker, inference in another.
-
-> **v1.2.0** | Parakeet-TDT v2 (English) and v3 (Multilingual, 13 languages)
-
----
-
-## What's New in v1.2.0 (Memory Safety, Decode Speedups & Streaming Demo)
-
-### Performance & Memory
-- **Tensor Disposal**: Systematic `dispose()` calls for all per-call ORT tensors (input, encoder output, joiner logits, decoder state) to prevent WASM/GPU memory leaks on repeated calls.
-- **Array Slicing Optimization**: Replaced `slice()` with `subarray()` in the decoding loop -- zero-copy view into the joiner output buffer (~22x faster for logit extraction in microbenchmarks).
-- **LRU Cache Eviction**: Added `maxIncrementalCacheSize` (default 50) to cap the incremental decoder cache and prevent unbounded memory growth during long sessions.
-- **Tokenizer Pre-computation**: Sanitized tokens are pre-computed in the constructor, removing per-decode regex work.
-- **Incremental Mel Optimization**: Faster incremental mel frame calculation path in `IncrementalMelProcessor`.
-- **Conditional Performance Logging**: `console.log`/`console.table` in the decode path is now gated behind `enableProfiling`, reducing overhead when profiling is off.
-
-### Streaming Transcription with Sliding Window and Cached Decoder
-- The library's incremental decoder cache (`incremental: { cacheKey, prefixSeconds }`) and `precomputedFeatures` path were validated in a production real-time app ([keet](https://github.com/ysdede/keet)) with measurable results:
-
-| Stage | Before | After |
-|-------|--------|-------|
-| Preprocess | 181 ms | **0 ms** (mel worker + `precomputedFeatures`) |
-| Decode | 133 ms | **19-99 ms** (incremental cache skips overlap prefix) |
-| Total | 787 ms | **187-265 ms** |
-| Real-time factor | 6.3x | **19-27x** |
-
-- The sliding-window pattern: a dedicated mel Web Worker continuously produces raw log-mel frames; when inference triggers, normalized features for the window are ready instantly. The encoder runs on WebGPU, and the decoder reuses its LSTM state from the previous window's overlap boundary via `cacheKey`/`prefixSeconds`, skipping ~80% of decoder frames for typical overlap ratios.
-- `precomputedFeatures` (v1.1.1) removes preprocessing from the inference thread entirely. `subarray()` (v1.2.0) and tensor disposal (v1.2.0) keep the hot loop fast and memory-stable across hundreds of consecutive calls.
-
-### Developer Experience
-- **Static Import Refactoring**: Switched to static top-level imports in `src/index.js` for better bundler compatibility and IDE support.
-- **Subpath Exports**: Import only what you need (e.g., `parakeet.js/parakeet`, `parakeet.js/hub`) for smaller bundle footprints.
-- **Enhanced Demo**: Version display for both the library and ORT-web, plus real-time profiling toggles.
-- **Dynamic ORT Versioning**: Automatically derives the CDN URL for WASM binaries from the active runtime version.
-
-### Backward Compatibility
-- **`enableProfiling` defaults to `true`**: `result.metrics` is populated by default, matching v1.1.x behavior. Set `enableProfiling: false` to disable metric collection and get `metrics: null`.
-
----
-
-## What's New in v1.1.0 (Preprocessing Optimization)
-
-### Pure JS Mel Spectrogram -- Now Default
-- **Pure JavaScript mel spectrogram is now the default** (`preprocessorBackend: 'js'`). Eliminates ONNX Runtime overhead and skips the ~5MB ONNX preprocessor model download.
-- Matches NeMo's pipeline exactly (pre-emphasis, STFT, Slaney mel filterbank, log, normalization). Cross-validated against ONNX reference with max error < 4e-4.
-- Switch back to ONNX with `preprocessorBackend: 'onnx'` in config.
-
-### Incremental Mel Caching for Streaming
-- `IncrementalMelProcessor` caches raw mel frames across overlapping streaming windows.
-- Integrated into `transcribe()` via `prefixSamples` option. For typical 70% overlap: ~60-70% preprocessing savings.
-- Exact numerical match with full computation.
-- Call `model.resetMelCache()` when starting a new recording session.
-
-### Other Changes
-- **Runtime preprocessor switching**: `model.setPreprocessorBackend('js' | 'onnx')` and `model.getPreprocessorBackend()`.
-- **Preprocessor warm-up**: Runs automatically during `fromUrls()` model loading.
-- **Known issue**: Some ONNX preprocessor model artifacts in external repos may use older preprocessing logic. The default JS preprocessor implements the corrected version.
-
----
-
-## What's New in v1.0.0
-
-**First stable release with NeMo-aligned accuracy and multilingual support.**
-
-### NeMo-Aligned TDT Decoding (Critical Accuracy Fix)
-- **100% Parity with NVIDIA NeMo**: Aligned the JavaScript TDT decoding loop with the original Python reference implementation.
-- **Fixed "Missing Words" Bug**: Resolved an issue where multi-token emissions from a single frame were being skipped due to incorrect frame advancement.
-- **Conditional State Updates**: Decoder state now correctly updates only upon non-blank token emission, matching the official transducer algorithm.
-- **Dynamic Vocabulary Mapping**: Replaced hardcoded blank IDs with dynamic lookup from the model's vocabulary.
-
-### Parakeet TDT v3 Multilingual Support
-- Added support for **Parakeet TDT 0.6B v3** with 13 languages: English, French, German, Spanish, Italian, Portuguese, Dutch, Polish, Russian, Ukrainian, Japanese, Korean, Chinese.
-- Both v2 (English-only) and v3 (Multilingual) models now work out of the box.
-- New Model Configuration API for programmatic access to model metadata and language support.
-
-### Enhanced Developer Experience
-- **Model Configuration API**: Query supported languages and model metadata programmatically.
-- **Improved Demo UI**: Modern design with automatic dark mode support.
-- **Speech Dataset Testing**: Integration with HuggingFace datasets for quick validation.
-- **Audio Playback**: Listen to loaded test samples directly in the demo.
-
-### Performance and Stability
-- Incremental transcription capabilities for real-time applications.
-- Optimized state snapshots for low-latency prefix caching.
-- Stable core API.
-
----
+`parakeet.js` is browser speech-to-text for NVIDIA Parakeet ONNX models. It runs fully client-side using `onnxruntime-web` with WebGPU or WASM execution.
 
 ## Installation
 
 ```bash
-# npm
 npm i parakeet.js
-
-# yarn
+# or
 yarn add parakeet.js
 ```
 
-`onnxruntime-web` is bundled as a dependency and supplies the runtime back-ends (WebGPU, WASM).
+- Use WebGPU when available for best throughput.
+- Use WASM when WebGPU is not available or for compatibility-first setups.
 
-TypeScript users:
-- The package ships bundled declarations via the top-level `"types"` field.
-- Subpath declaration resolution via `exports.types` works in TS 4.7+ when `moduleResolution` is `node16`, `nodenext`, or `bundler`. If your toolchain is older, use the root import (`parakeet.js`) or upgrade TypeScript.
-
----
-
-## Model assets
-
-We host ready-to-use ONNX exports on the HuggingFace Hub:
-
-| Model | Languages | Repo ID |
-|-------|-----------|---------|
-| Parakeet TDT 0.6B v2 | English | `istupakov/parakeet-tdt-0.6b-v2-onnx` |
-| Parakeet TDT 0.6B v3 | 13 languages | `istupakov/parakeet-tdt-0.6b-v3-onnx` |
-
-The helper `getParakeetModel()` downloads all required files and caches them in **IndexedDB**:
+## Quickstart
 
 ```js
-import { getParakeetModel, MODELS } from 'parakeet.js';
+import { fromHub } from 'parakeet.js';
 
-// Option 1: Use model key (recommended)
-const { urls, filenames, modelConfig } = await getParakeetModel('parakeet-tdt-0.6b-v3', {
-  backend: 'webgpu',
-  progress: ({file,loaded,total}) => console.log(file, loaded/total)
-});
+async function decodeToMono16k(file) {
+  const arrayBuffer = await file.arrayBuffer();
+  const ctx = new AudioContext({ sampleRate: 16000 });
+  const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
 
-// Option 2: Use repo ID directly
-const { urls, filenames } = await getParakeetModel('istupakov/parakeet-tdt-0.6b-v2-onnx', {
+  let pcm;
+  if (audioBuffer.numberOfChannels === 1) {
+    pcm = audioBuffer.getChannelData(0);
+  } else {
+    const mono = new Float32Array(audioBuffer.length);
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      const channel = audioBuffer.getChannelData(ch);
+      for (let i = 0; i < mono.length; i++) mono[i] += channel[i] / audioBuffer.numberOfChannels;
+    }
+    pcm = mono;
+  }
+
+  await ctx.close();
+  return pcm;
+}
+
+const model = await fromHub('parakeet-tdt-0.6b-v3', {
   backend: 'webgpu',
   encoderQuant: 'fp32',
   decoderQuant: 'int8',
-  preprocessor: 'onnx-preprocessor',
-});
-```
-
-Returned structure:
-
-```ts
-{
-  urls: {
-    encoderUrl: string,
-    decoderUrl: string,
-    encoderDataUrl?: string | null,
-    decoderDataUrl?: string | null,
-    tokenizerUrl: string,
-    preprocessorUrl: string
-  },
-  filenames: { encoder: string; decoder: string }
-}
-```
-
----
-
-## Creating a model instance
-
-```js
-import { ParakeetModel } from 'parakeet.js';
-
-const model = await ParakeetModel.fromUrls({
-  ...urls,                 // spread the URLs returned above
-  filenames,               // needed for external .data mapping
-  backend: 'webgpu',       // 'webgpu' or 'wasm'
-  cpuThreads: 6,           // For WASM backend
-  verbose: false,          // ORT verbose logging
-});
-```
-
-If you want smaller startup in non-bundled ESM environments, import only what you need via subpath exports:
-
-```js
-import { ParakeetModel } from 'parakeet.js/parakeet';
-// or: import { fromHub } from 'parakeet.js/hub';
-```
-
-### Quick Start: English Model (v2)
-
-```js
-import { fromHub } from 'parakeet.js';
-
-// Load English-only model
-const model = await fromHub('parakeet-tdt-0.6b-v2', {
-  backend: 'webgpu',
-  progress: ({ file, loaded, total }) => {
-    console.log(`${file}: ${Math.round(loaded/total*100)}%`);
-  }
 });
 
-// Transcribe audio
-const result = await model.transcribe(pcmFloat32, 16000);
+// `file` should be a File (for example from <input type="file">)
+const pcm = await decodeToMono16k(file);
+const result = await model.transcribe(pcm, 16000, {
+  returnTimestamps: true,
+  returnConfidences: true,
+});
+
 console.log(result.utterance_text);
 ```
 
-### Quick Start: Multilingual Model (v3)
+## Loading models
+
+- `fromHub(repoIdOrModelKey, options)`: easiest path. Accepts model keys like `parakeet-tdt-0.6b-v3` or full repo IDs.
+- `fromUrls(cfg)`: explicit URL wiring when you host assets yourself.
 
 ```js
-import { fromHub } from 'parakeet.js';
+import { fromUrls } from 'parakeet.js';
 
-// Load multilingual model (supports 13 languages)
-const model = await fromHub('parakeet-tdt-0.6b-v3', {
-  backend: 'webgpu'
-});
-
-// Works with any supported language automatically
-const frenchResult = await model.transcribe(frenchAudio, 16000);
-const germanResult = await model.transcribe(germanAudio, 16000);
-```
-
-### Back-end presets
-
-The library supports two primary backends: `webgpu` and `wasm`.
-
-- **`webgpu` (Default):** This is the fastest option for modern desktop browsers. It runs in a hybrid configuration:
-  - The heavy **encoder** model runs on the **GPU** (WebGPU) for maximum throughput.
-  - The **decoder** model runs on the **CPU** (WASM). The decoder's architecture contains operations not fully supported by the ONNX Runtime WebGPU backend, causing it to fall back to WASM anyway. This configuration makes the behavior explicit and stable, avoiding performance issues and warnings.
-  - In this mode, the encoder must be `fp32`, but you can choose `fp32` or `int8` for the decoder.
-
-- **`wasm`:** Both encoder and decoder run on the CPU. This is best for compatibility with older devices or environments without WebGPU support. Both models can be `fp32` or `int8`.
-
-
----
-
-## Transcribing audio
-
-```js
-// 16-kHz mono PCM Float32Array
-await model.transcribe(pcmFloat32, 16_000, {
-  returnTimestamps: true,
-  returnConfidences: true,
-  frameStride: 2,      // 1 (default) = highest accuracy / 2-4 faster
+const model = await fromUrls({
+  encoderUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx',
+  decoderUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.int8.onnx',
+  tokenizerUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt',
+  // Only needed if you choose preprocessorBackend: 'onnx'
+  preprocessorUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx',
+  backend: 'webgpu-hybrid',
+  preprocessorBackend: 'js',
 });
 ```
 
-Extra options:
+## Backends and quantization
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `temperature` | 1.0 | Softmax temperature for decoding (1.0 = greedy, >1.0 = sampling) |
-| `frameStride` | 1 | Advance decoder by *n* encoder frames per step |
-| `enableProfiling` | true | Collect timing metrics and populate `result.metrics`. Set to `false` to disable. |
-| `returnLogProbs` | false | Return per-token log probabilities |
-| `timeOffset` | 0 | Time offset (seconds) to add to all timestamps |
-| `prefixSamples` | 0 | Number of overlapping prefix samples for incremental mel caching |
-| `precomputedFeatures` | null | Pre-computed mel features (see [Streaming with Pre-computed Features](#streaming-with-pre-computed-features)) |
-| `incremental` | null | Incremental decoder cache config (see [Incremental Decoder Cache](#incremental-decoder-cache)) |
+- Backends are selected with `backend`:
+  - `webgpu` (alias accepted)
+  - `wasm`
+  - advanced: `webgpu-hybrid`, `webgpu-strict`
+- In WebGPU modes, the decoder session runs on WASM (hybrid execution).
+- In `getParakeetModel`/`fromHub`, if backend starts with `webgpu` and `encoderQuant` is `int8`, encoder quantization is forced to `fp32`.
+- Decoder quantization can be `int8` or `fp32`.
+- `preprocessorBackend` is `js` (default) or `onnx`.
 
-### Streaming with Pre-computed Features
+## Transcribing a file (single-shot)
 
-For streaming applications that compute mel spectrograms in a separate worker, you can bypass the built-in preprocessor entirely:
+The demo flow in `examples/demo/src/App.jsx` is:
+1. Load model assets via `getParakeetModel(...)` and create a model with `ParakeetModel.fromUrls(...)`.
+2. Decode uploaded audio with `AudioContext({ sampleRate: 16000 })` + `decodeAudioData(...)`.
+3. Read mono PCM from `decoded.getChannelData(0)`.
+4. Call `model.transcribe(pcm, 16000, options)` and render `utterance_text`.
 
-```js
-const result = await model.transcribe(null, 16000, {
-  precomputedFeatures: {
-    features: melFloat32Array,  // [T * melBins] row-major Float32Array
-    T: 500,                     // number of time frames
-    melBins: 128                // number of mel bands
-  }
-});
-```
+Reference code:
+- `examples/demo/src/App.jsx:275`
+- `examples/demo/src/App.jsx:348`
 
-When `precomputedFeatures` is provided:
-- The audio parameter can be `null` (audio is not needed)
-- The built-in preprocessor (JS or ONNX) is completely skipped
-- Features must be normalized (zero mean, unit variance per feature)
-- This enables **pipeline parallelism**: compute mel in one worker, run inference in another
+## Results
 
-### Incremental Decoder Cache
-
-For overlapping streaming windows, the decoder can cache its state to avoid re-decoding the overlapping prefix:
-
-```js
-const result = await model.transcribe(audio, 16000, {
-  incremental: {
-    cacheKey: 'stream-1',     // unique key for this stream
-    prefixSeconds: 3.5        // seconds of overlap to cache
-  },
-  timeOffset: windowStartTime  // adjust timestamps for the window position
-});
-```
-
-The cache stores decoder state at the prefix boundary. On the next call with the same `cacheKey`, frames up to `prefixSeconds` are skipped, reducing decoder time by **~80%** for typical overlap ratios.
-
-You can tune the cache size with `maxIncrementalCacheSize` (default `50`) when constructing the model. Increase it for many concurrent streams to avoid LRU evictions; in `debug` mode, evictions are logged to help with tuning.
-
-Call `model.clearIncrementalCache()` when starting a new recording session.
-
-### Result schema
+`model.transcribe(...)` returns a `TranscribeResult` with this shape:
 
 ```ts
-{
-  utterance_text: string,
-  words: Array<{text,start_time,end_time,confidence}>,
-  tokens: Array<{token,start_time,end_time,confidence}>,
-  confidence_scores: { overall_log_prob, word_avg, token_avg },
-  metrics: {               // null when enableProfiling: false
-    rtf: number,
-    total_ms: number,
-    preprocess_ms: number,
-    encode_ms: number,
-    decode_ms: number,
-    tokenize_ms: number
-  } | null,
-  is_final: boolean
-}
+type TranscribeResult = {
+  utterance_text: string;
+  words: Array<{
+    text: string;
+    start_time: number;
+    end_time: number;
+    confidence?: number;
+  }>;
+  tokens?: Array<{
+    token: string;
+    raw_token?: string;
+    is_word_start?: boolean;
+    start_time?: number;
+    end_time?: number;
+    confidence?: number;
+  }>;
+  confidence_scores?: {
+    token?: number[] | null;
+    token_avg?: number | null;
+    word?: number[] | null;
+    word_avg?: number | null;
+    frame: number[] | null;
+    frame_avg: number | null;
+    overall_log_prob: number | null;
+  };
+  metrics?: {
+    preprocess_ms: number;
+    encode_ms: number;
+    decode_ms: number;
+    tokenize_ms: number;
+    total_ms: number;
+    rtf: number;
+    mel_cache?: { cached_frames: number; new_frames: number };
+  } | null;
+  is_final: boolean;
+  tokenIds?: number[];
+  frameIndices?: number[];
+  logProbs?: number[];
+  tdtSteps?: number[];
+};
 ```
 
----
+- Enable `returnTimestamps` for meaningful `start_time`/`end_time`.
+- Enable `returnConfidences` for per-token/per-word confidence fields.
+- Advanced alignment/debug outputs are opt-in: `returnTokenIds`, `returnFrameIndices`, `returnLogProbs`, `returnTdtSteps`.
 
-## Warm-up & Verification (Recommended)
+## Real-time streaming (Keet)
 
-The first time you run inference after loading a model, the underlying runtime needs to compile the execution graph. This makes the first run significantly slower. To ensure a smooth user experience, it's best practice to perform a "warm-up" run with a dummy or known audio sample immediately after model creation.
+[Keet](https://ysdede.github.io/keet/) is a reference real-time app built on `parakeet.js` ([repo](https://github.com/ysdede/keet)).
 
-Our React demo does this and also verifies the output to ensure the model loaded correctly.
+- For contiguous chunk streams, Keet uses `createStreamingTranscriber(...)`.
+- Keet currently defaults to v4 utterance-based merging (`UtteranceBasedMerger`) with cursor/windowed chunk processing.
 
-```js
-// In your app, after `ParakeetModel.fromUrls()` succeeds:
-setStatus('Warming up & verifying…');
+<a href="https://ysdede.github.io/keet/" target="_blank" rel="noopener noreferrer">
+  <img src="https://raw.githubusercontent.com/ysdede/keet/refs/heads/master/public/img/streaming-preview.jpg" alt="Real-time transcription with Keet and parakeet.js" />
+</a>
 
-const audioRes = await fetch('/assets/known_audio.wav');
-const pcm = await decodeAudio(audioRes); // Your audio decoding logic
-const { utterance_text } = await model.transcribe(pcm, 16000);
+## API Reference
 
-const expected = 'the known transcript for your audio';
-if (utterance_text.toLowerCase().includes(expected)) {
-  setStatus('Model ready');
-} else {
-  setStatus('Model verification failed!');
-}
-```
-
----
-
-## Runtime tuning knobs
-
-| Property | Where | Effect |
-|----------|-------|--------|
-| `cpuThreads` | `fromUrls()` | Sets `ort.env.wasm.numThreads`; pick *cores-2* for best balance |
-| `encoderQuant` | `getParakeetModel()` | Selects `fp32` or `int8` model for the encoder |
-| `decoderQuant` | `getParakeetModel()` | Selects `fp32` or `int8` model for the decoder |
-| `preprocessorBackend` | `getParakeetModel()` / `fromUrls()` | `'js'` (default) uses pure JS mel; `'onnx'` uses the ONNX preprocessor path |
-| `frameStride` | `transcribe()` | Trade-off latency vs accuracy |
-| `precomputedFeatures` | `transcribe()` | Bypass preprocessor with external mel features |
-| `enableProfiling` | `transcribe()` | Populates `result.metrics` with timing data (default `true`). Set `false` to skip metric collection. |
-| `enableProfiling` | `fromUrls()` | Enables ORT session profiler (JSON written to `/tmp/profile_*.json`; default `false`) |
-
----
-
-## Model Configuration API
-
-Query model metadata programmatically:
-
-```js
-import { MODELS, LANGUAGE_NAMES, getModelConfig, supportsLanguage } from 'parakeet.js';
-
-// List all available models
-console.log(Object.keys(MODELS)); 
-// ['parakeet-tdt-0.6b-v2', 'parakeet-tdt-0.6b-v3']
-
-// Get model config
-const config = getModelConfig('parakeet-tdt-0.6b-v3');
-console.log(config.languages); // ['en', 'fr', 'de', 'es', ...]
-console.log(config.displayName); // 'Parakeet TDT 0.6B v3 (Multilingual)'
-
-// Check language support
-supportsLanguage('parakeet-tdt-0.6b-v3', 'fr'); // true
-supportsLanguage('parakeet-tdt-0.6b-v2', 'fr'); // false
-
-// Get language display names
-console.log(LANGUAGE_NAMES['fr']); // 'French'
-```
-
----
-
-## Using the React Demo
-
-The library includes a unified demo application:
-
-```
-examples/demo/          # React demo with switchable source
-```
-
-### Quick Start
+- Published API docs: https://ysdede.github.io/parakeet.js/api/
+- Generate locally:
 
 ```bash
-cd examples/demo
-npm install
-
-# Test with local source files (for library development)
-npm run dev:local
-
-# Test with npm package (simulates end-user experience)
-npm run dev
+npm run docs:api
 ```
 
-The demo runs at `http://localhost:3000/` with CORS headers enabled for SharedArrayBuffer support.
+## License
 
-### Deployment
-
-```bash
-# Deploy to HuggingFace Spaces
-npm run deploy-to-hf
-
-# Trigger GitHub Pages deploy manually (optional)
-gh workflow run deploy-gh-pages.yml
-```
-
-GitHub Pages is normally auto-deployed by the `deploy-gh-pages.yml` workflow when `examples/demo/**` or `src/**` changes on `master`. The workflow uses `build:local`, so the live page reflects the latest repository source rather than waiting for an npm release.
-
-### Demo Features
-
-All demos share the same modern UI with:
-
-- **Model Selector**: Switch between v2 (English) and v3 (Multilingual)
-- **Language Selector**: Context-aware dropdown showing only supported languages
-- **Quick Test**: Load random samples from HuggingFace speech datasets
-- **Reference Text**: Compare transcription against ground truth
-- **Dark Mode**: Automatic theme toggle
-- **Version Display**: Shows the active `parakeet.js` version/source and the loaded `onnxruntime-web` runtime version
-
-### Speech Dataset Utilities (Demo Only)
-
-The demo includes reusable utilities for testing with HuggingFace datasets:
-
-```js
-// Located in: examples/react-demo-dev/src/utils/speechDatasets.js
-import { fetchRandomSample, hasTestSamples, SPEECH_DATASETS } from './utils/speechDatasets';
-
-// Check if test samples are available for a language
-if (hasTestSamples('fr')) {
-  // Fetch a random French audio sample with transcription
-  const sample = await fetchRandomSample('fr', {
-    targetSampleRate: 16000,
-    onProgress: ({ message }) => console.log(message),
-  });
-  
-  console.log(sample.transcription); // Ground truth text
-  console.log(sample.pcm);           // Float32Array audio
-  console.log(sample.duration);      // Duration in seconds
-}
-```
-
-**Supported languages for testing:** English (People's Speech), French, German, Spanish, Italian, Portuguese, Dutch, Polish (Multilingual LibriSpeech)
-
-### Key Files
-
-| File | Purpose |
-|------|---------|
-| `App.jsx` | Complete end-to-end reference UI with model/language selection, performance metrics, and transcription history |
-| `utils/speechDatasets.js` | Reusable utilities for fetching test samples from HuggingFace datasets |
-
-Copy-paste the `loadModel()` and `transcribeFile()` functions into your app, adjust UI bindings, and you are ready to go.
-
----
-
-## Testing
-
-The library includes a Vitest test suite (82 tests across 7 suites):
-
-```bash
-npm test          # Run all tests once
-npm run test:watch  # Watch mode
-```
-
-### Test Suites
-
-| Suite | Tests | Description |
-|---|---|---|
-| `mel.test.mjs` | 39 | Mel constants, filterbank, FFT, JsPreprocessor, IncrementalMelProcessor, ONNX cross-validation |
-| `preprocessor-selection.test.mjs` | 16 | Hub file selection logic, fromUrls preprocessor creation, default config |
-| `precomputed-features.test.mjs` | 15 | Feature format, audioDur computation, edge cases, integration |
-| `transcribe_perf.test.mjs` | 5 | Profiling/metrics behavior, tensor disposal verification |
-| `incremental_cache_fix.test.mjs` | 2 | LRU incremental decoder cache, cache clearing |
-| `stateful-streaming.test.mjs` | 3 | StatefulStreamingTranscriber state handoff, finalize/reset, and explicit non-dedupe behavior |
-| `index.test.mjs` | 2 | Top-level `fromUrls` and `fromHub` exports |
-
----
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `Some nodes were not assigned...` warning | When using the `webgpu` backend, ORT assigns minor operations (`Shape`, `Gather`, etc.) in the encoder to the CPU for efficiency. | This is expected and harmless. The heavy-lifting is still on the GPU. |
-| GPU memory still ~2.4 GB with INT8 selected | In WebGPU mode, the encoder must be `fp32`. The `int8` option only applies to the WASM backend or the decoder in hybrid mode. | This is the expected behavior for the `webgpu` backend. |
-| `Graph capture feature not available` error | Mixed EPs (CPU/GPU) or unsupported ops prevent GPU graph capture. | The library automatically retries without capture; safe to ignore. |
-
----
-
-## Changelog
-
-### v1.2.0 (February 2026) -- Memory Safety, Decode Speedups & Streaming Demo
-
-- **Tensor Disposal**: Systematic `dispose()` calls for all per-call ORT tensors to prevent WASM/GPU memory leaks.
-- **`subarray()` Optimization**: Zero-copy view replaces `slice()` in the decode hot loop (~22x faster logit extraction).
-- **LRU Cache Eviction**: `maxIncrementalCacheSize` (default 50) caps the incremental decoder cache.
-- **Tokenizer Pre-computation**: Sanitized tokens built once in constructor.
-- **Incremental Mel Optimization**: Faster frame calculation in `IncrementalMelProcessor`.
-- **Conditional Perf Logging**: `console.log`/`console.table` gated behind `enableProfiling`.
-- **`enableProfiling` backward compat**: Defaults to `true` so `result.metrics` is populated by default (matching v1.1.x). Set `false` to disable.
-- **Static Import Refactor**: `src/index.js` uses static top-level imports for better bundler compatibility.
-- **Subpath Exports**: Import specific modules (e.g., `parakeet.js/parakeet`) for smaller bundles.
-- **Dynamic ORT Versioning**: WASM CDN paths derived automatically from the active runtime.
-- **Streaming demo validated**: Sliding-window transcription with mel worker + `precomputedFeatures` + incremental decoder cache demonstrated 19-27x real-time in [keet](https://github.com/ysdede/keet).
-
-### v1.1.1 (February 2026) -- Streaming Enhancements & Test Suite
-
-- **`precomputedFeatures` option**: `transcribe()` accepts pre-computed mel spectrograms, bypassing the built-in preprocessor.
-- **Conditional ONNX loading**: `fromUrls()` and `getParakeetModel()` skip the ONNX preprocessor model when `preprocessorBackend: 'js'` (~5MB saved).
-- **`timeOffset` bugfix**: Fixed `effectiveTimeOffset` in incremental decoder cache path.
-- **Vitest test suite**: Automated tests for mel accuracy, preprocessor selection, and feature format.
-- **New exports**: `hzToMel`, `melToHz` from `mel.js`.
-
-### v1.0.0 (January 2026)
-**First stable release**
-
-- **Accuracy Alignment**: Critical fix for TDT decoding loop to match NVIDIA NeMo parity.
-- **Multi-token Fix**: Resolved bug skipping tokens emitted from the same encoder frame.
-- **Space Normalization**: Improved SentencePiece decoding regex for better punctuation spacing.
-- **Dynamic Blank ID**: Automatic detection of blank token index from model vocabulary.
-- **Multilingual Support**: Added Parakeet TDT 0.6B v3 with 13 languages.
-- **Model Config API**: New `MODELS`, `LANGUAGE_NAMES`, `getModelConfig()`, `supportsLanguage()` exports.
-- **Demo Enhancements**: Modern UI with dark mode, model/language selectors, HuggingFace dataset testing.
-- **Streaming Support**: Incremental transcription capabilities for real-time applications.
-
-### v0.4.x
-- Accuracy improvements and multilingual foundation
-
-### v0.3.x
-- Initial multilingual experiments
-
-### v0.2.x
-- Initial WebGPU/WASM hybrid backend
-- IndexedDB model caching
-- Performance instrumentation (RTF, timing metrics)
-
----
+MIT
 
 ## Credits
 
-This project builds upon the excellent work of:
-
-- **[istupakov](https://github.com/istupakov)** - For providing the [ONNX-ASR](https://github.com/istupakov/onnx-asr) repository, which served as the foundation and starting point for this JavaScript implementation
-
-The Python-based ONNX-ASR project provided crucial insights into model handling, preprocessing pipelines, and served as a reference implementation during the development of this browser-compatible version.
-
-Happy hacking!
+- [istupakov/onnx-asr](https://github.com/istupakov/onnx-asr) for the reference implementation and model tooling foundations.

--- a/README.md
+++ b/README.md
@@ -92,14 +92,13 @@ const model = await fromUrls({
 ## Transcribing a file (single-shot)
 
 The demo flow in `examples/demo/src/App.jsx` is:
-1. Load model assets via `getParakeetModel(...)` and create a model with `ParakeetModel.fromUrls(...)`.
+1. Load a model with public APIs (`fromHub(...)` for hub loading, or `fromUrls(...)` for explicit URLs).
 2. Decode uploaded audio with `AudioContext({ sampleRate: 16000 })` + `decodeAudioData(...)`.
-3. Read mono PCM from `decoded.getChannelData(0)`.
+3. Convert decoded audio to mono 16 kHz PCM (`Float32Array`) by averaging channels when needed.
 4. Call `model.transcribe(pcm, 16000, options)` and render `utterance_text`.
 
 Reference code:
-- `examples/demo/src/App.jsx:275`
-- `examples/demo/src/App.jsx:348`
+- `App` component in `examples/demo/src/App.jsx` (`loadModel` / `transcribeFile` flow)
 
 ## Results
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "onnxruntime-web": "1.24.1"
       },
       "devDependencies": {
+        "typedoc": "^0.28.17",
         "vitest": "^4.0.18"
       }
     },
@@ -457,6 +458,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.22.0.tgz",
+      "integrity": "sha512-jMpciqEVUBKE1QwU64S4saNMzpsSza6diNCk4MWAeCxO2+LFi2FIFmL2S0VDLzEJCxuvCbU783xi8Hp/gkM5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.22.0",
+        "@shikijs/langs": "^3.22.0",
+        "@shikijs/themes": "^3.22.0",
+        "@shikijs/types": "^3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -878,6 +893,55 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
+      "integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
+      "integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
+      "integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -910,6 +974,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.0.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.11.tgz",
@@ -918,6 +992,13 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
@@ -1030,6 +1111,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1040,6 +1128,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1048,6 +1159,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1164,11 +1288,28 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1178,6 +1319,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nanoid": {
@@ -1316,6 +1498,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -1435,6 +1627,52 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/typedoc": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.17.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",
@@ -1610,6 +1848,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
   ],
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "docs:clean": "node -e \"require('fs').rmSync('.typedoc-site', { recursive: true, force: true })\"",
+    "docs:api": "typedoc --options typedoc.json",
+    "docs:build": "npm run docs:clean && npm run docs:api"
   },
   "dependencies": {
     "onnxruntime-web": "1.24.1"
@@ -60,6 +63,7 @@
     "url": "https://github.com/ysdede/parakeet.js/issues"
   },
   "devDependencies": {
+    "typedoc": "^0.28.17",
     "vitest": "^4.0.18"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,15 @@
+{
+  "entryPoints": [
+    "types/index.d.ts",
+    "types/parakeet.d.ts",
+    "types/hub.d.ts",
+    "types/models.d.ts",
+    "types/mel.d.ts"
+  ],
+  "out": ".typedoc-site",
+  "name": "parakeet.js API",
+  "sort": [
+    "source-order"
+  ],
+  "categorizeByGroup": false
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,6 +6,7 @@
     "types/models.d.ts",
     "types/mel.d.ts"
   ],
+  "entryPointStrategy": "resolve",
   "out": ".typedoc-site",
   "name": "parakeet.js API",
   "sort": [


### PR DESCRIPTION
Summary
- rewrite README to focus on how to use parakeet.js (quickstart-first, shorter sections)
- correct backend/usage guidance to match current code paths
- add TypeDoc generation config and scripts
- publish API docs to GitHub Pages under /api in the existing deploy workflow

Changes
- README.md: full restructure, removed release-note/timeline/perf-table content
- 	ypedoc.json: new TypeDoc config using shipped declaration entrypoints
- package.json: add docs:clean, docs:api, docs:build, and 	ypedoc devDependency
- package-lock.json: dependency lock updates for TypeDoc
- .github/workflows/deploy-gh-pages.yml: build docs and copy to deploy_temp/api; include docs-related path triggers

Verification
- 
pm run docs:api (passes; generates .typedoc-site/index.html)