### PR TITLE
feat: finalize fp16 support with strict core loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ console.log(result.utterance_text);
 import { fromUrls } from 'parakeet.js';
 
 const model = await fromUrls({
-  encoderUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx',
-  decoderUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.int8.onnx',
-  tokenizerUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt',
+  encoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx',
+  decoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.int8.onnx',
+  tokenizerUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt',
   // Only needed if you choose preprocessorBackend: 'onnx'
-  preprocessorUrl: 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx',
+  preprocessorUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx',
   backend: 'webgpu-hybrid',
   preprocessorBackend: 'js',
 });
@@ -112,9 +112,9 @@ Use explicit FP16 URLs:
 import { fromUrls } from 'parakeet.js';
 
 const model = await fromUrls({
-  encoderUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/encoder-model.fp16.onnx',
-  decoderUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/decoder_joint-model.fp16.onnx',
-  tokenizerUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/vocab.txt',
+  encoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/encoder-model.fp16.onnx',
+  decoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/decoder_joint-model.fp16.onnx',
+  tokenizerUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/vocab.txt',
   preprocessorBackend: 'js',
   backend: 'webgpu-hybrid',
 });

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ const model = await fromUrls({
 
 ## FP16 Examples
 
+Before using FP16 examples: ensure FP16 artifacts exist in the target repo and your browser/runtime supports FP16 execution (WebGPU FP16 path).
+
 Load known FP16 model key:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Use explicit FP16 URLs:
 import { fromUrls } from 'parakeet.js';
 
 const model = await fromUrls({
-  encoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/encoder-model.fp16.onnx',
-  decoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/decoder_joint-model.fp16.onnx',
-  tokenizerUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/feat/fp16-canonical-v3/vocab.txt',
+  encoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.fp16.onnx',
+  decoderUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.fp16.onnx',
+  tokenizerUrl: 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt',
   preprocessorBackend: 'js',
   backend: 'webgpu-hybrid',
 });

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ async function decodeToMono16k(file) {
 
 const model = await fromHub('parakeet-tdt-0.6b-v3', {
   backend: 'webgpu',
-  encoderQuant: 'fp32',
-  decoderQuant: 'int8',
+  encoderQuant: 'fp16',
+  decoderQuant: 'fp16',
 });
 
 // `file` should be a File (for example from <input type="file">)
@@ -86,8 +86,39 @@ const model = await fromUrls({
   - advanced: `webgpu-hybrid`, `webgpu-strict`
 - In WebGPU modes, the decoder session runs on WASM (hybrid execution).
 - In `getParakeetModel`/`fromHub`, if backend starts with `webgpu` and `encoderQuant` is `int8`, encoder quantization is forced to `fp32`.
-- Decoder quantization can be `int8` or `fp32`.
+- Encoder/decoder quantization supports `int8`, `fp32`, and `fp16`.
+- FP16 requires FP16 ONNX artifacts (for example `encoder-model.fp16.onnx`).
+- ONNX Runtime Web does **not** convert FP32 model files into FP16 at load time.
+- If `fp16` is requested but missing in a repo, loading falls back to `fp32` for that component.
 - `preprocessorBackend` is `js` (default) or `onnx`.
+
+## FP16 Examples
+
+Load known FP16 model key:
+
+```js
+import { fromHub } from 'parakeet.js';
+
+const model = await fromHub('parakeet-tdt-0.6b-v3-fp16', {
+  backend: 'webgpu-hybrid',
+  encoderQuant: 'fp16',
+  decoderQuant: 'fp16',
+});
+```
+
+Use explicit FP16 URLs:
+
+```js
+import { fromUrls } from 'parakeet.js';
+
+const model = await fromUrls({
+  encoderUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/encoder-model.fp16.onnx',
+  decoderUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/decoder_joint-model.fp16.onnx',
+  tokenizerUrl: 'https://huggingface.co/grikdotnet/parakeet-tdt-0.6b-fp16/resolve/main/vocab.txt',
+  preprocessorBackend: 'js',
+  backend: 'webgpu-hybrid',
+});
+```
 
 ## Transcribing a file (single-shot)
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ async function decodeToMono16k(file) {
 }
 
 const model = await fromHub('parakeet-tdt-0.6b-v3', {
-  backend: 'webgpu',
-  encoderQuant: 'fp16',
-  decoderQuant: 'fp16',
+  backend: 'webgpu-hybrid',
+  encoderQuant: 'fp32',
+  decoderQuant: 'int8',
 });
 
 // `file` should be a File (for example from <input type="file">)

--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ const model = await fromUrls({
   - `webgpu` (alias accepted)
   - `wasm`
   - advanced: `webgpu-hybrid`, `webgpu-strict`
-- In WebGPU modes, the decoder session runs on WASM (hybrid execution).
+- In WebGPU modes, the encoder prefers WebGPU but decoder session runs on WASM (hybrid execution).
 - In `getParakeetModel`/`fromHub`, if backend starts with `webgpu` and `encoderQuant` is `int8`, encoder quantization is forced to `fp32`.
 - Encoder/decoder quantization supports `int8`, `fp32`, and `fp16`.
 - FP16 requires FP16 ONNX artifacts (for example `encoder-model.fp16.onnx`).
 - ONNX Runtime Web does **not** convert FP32 model files into FP16 at load time.
-- If `fp16` is requested but missing in a repo, loading falls back to `fp32` for that component.
+- `getParakeetModel`/`fromHub` are strict about requested quantization: they do not auto-switch `fp16` to `fp32`.
+- If requested FP16 artifacts are missing or fail to load, API calls throw actionable errors so callers can choose a different quantization explicitly.
+- Decoder runs on WASM in WebGPU modes; if decoder FP16 is unsupported in your runtime, choose `decoderQuant: 'int8'` or `decoderQuant: 'fp32'` explicitly.
 - `preprocessorBackend` is `js` (default) or `onnx`.
 
 ## FP16 Examples
@@ -99,7 +101,7 @@ Load known FP16 model key:
 ```js
 import { fromHub } from 'parakeet.js';
 
-const model = await fromHub('parakeet-tdt-0.6b-v3-fp16', {
+const model = await fromHub('parakeet-tdt-0.6b-v3', {
   backend: 'webgpu-hybrid',
   encoderQuant: 'fp16',
   decoderQuant: 'fp16',

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -144,7 +144,7 @@ demo/
 ### Model loading fails with memory error
 - Check browser DevTools isn't pausing on potential OOM
 - Try closing other browser tabs to free memory
-- Prefer `fp16` on WebGPU (falls back to `fp32` if unavailable), or use `int8` for smallest files
+- Prefer `fp16` on WebGPU; this demo retries with `fp32` if `fp16` fails, while the core API does not auto-switch. Use `int8` for smallest files.
 
 ### Changes not reflected after deployment
 - GitHub Pages: Wait 1-2 minutes for CDN cache

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -144,7 +144,7 @@ demo/
 ### Model loading fails with memory error
 - Check browser DevTools isn't pausing on potential OOM
 - Try closing other browser tabs to free memory
-- Use int8 quantization for smaller models
+- Prefer `fp16` on WebGPU (falls back to `fp32` if unavailable), or use `int8` for smallest files
 
 ### Changes not reflected after deployment
 - GitHub Pages: Wait 1-2 minutes for CDN cache

--- a/examples/demo/src/App.css
+++ b/examples/demo/src/App.css
@@ -16,6 +16,18 @@
   background-color: #10b981;
 }
 
+/* Remove native select arrow so custom expand_more icon is the only one */
+select,
+select.appearance-none {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  background-image: none;
+}
+select::-ms-expand {
+  display: none;
+}
+
 /* Smooth transitions */
 input,
 select,

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -1,7 +1,36 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ParakeetModel, getParakeetModel, MODELS, LANGUAGE_NAMES } from 'parakeet.js';
 import { fetchRandomSample, hasTestSamples, SPEECH_DATASETS } from './utils/speechDatasets';
+import {
+  DEFAULT_MODEL_REVISIONS,
+  fetchModelRevisions,
+  fetchModelFiles,
+  getAvailableQuantModes,
+  pickPreferredQuant,
+} from '../../shared/modelSelection.js';
+import { formatResolvedQuantization, loadModelWithFallback } from '../../shared/modelLoader.js';
 import './App.css';
+
+const SETTINGS_STORAGE_KEY = 'parakeet.demo.settings.v1';
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveSettings(settings) {
+  try {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore storage failures (private mode/quota).
+  }
+}
 
 // Available models for selection
 const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
@@ -10,81 +39,6 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
   displayName: config.displayName,
   languages: config.languages,
 }));
-
-const DEFAULT_MODEL_REVISIONS = ['main'];
-const MODEL_REVISIONS_CACHE = new Map();
-const MODEL_FILES_CACHE = new Map();
-const QUANTIZATION_ORDER = ['fp16', 'int8', 'fp32'];
-
-function formatRepoPath(repoId) {
-  return repoId
-    .split('/')
-    .map((part) => encodeURIComponent(part))
-    .join('/');
-}
-
-async function fetchModelRevisions(repoId) {
-  if (!repoId) return DEFAULT_MODEL_REVISIONS;
-  if (MODEL_REVISIONS_CACHE.has(repoId)) {
-    return MODEL_REVISIONS_CACHE.get(repoId);
-  }
-
-  try {
-    const repoPath = formatRepoPath(repoId);
-    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/refs`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json();
-    const branches = Array.isArray(payload?.branches)
-      ? payload.branches.map((branch) => branch?.name).filter(Boolean)
-      : [];
-    const revisions = branches.length > 0 ? branches : DEFAULT_MODEL_REVISIONS;
-    MODEL_REVISIONS_CACHE.set(repoId, revisions);
-    return revisions;
-  } catch (error) {
-    console.warn(`[App] Failed to fetch revisions for ${repoId}; using defaults`, error);
-    return DEFAULT_MODEL_REVISIONS;
-  }
-}
-
-async function fetchModelFiles(repoId, revision) {
-  if (!repoId) return [];
-  const cacheKey = `${repoId}@${revision}`;
-  if (MODEL_FILES_CACHE.has(cacheKey)) {
-    return MODEL_FILES_CACHE.get(cacheKey);
-  }
-
-  try {
-    const repoPath = formatRepoPath(repoId);
-    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/tree/${encodeURIComponent(revision)}?recursive=1`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json();
-    const files = Array.isArray(payload)
-      ? payload.filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string').map((entry) => entry.path)
-      : [];
-    MODEL_FILES_CACHE.set(cacheKey, files);
-    return files;
-  } catch (error) {
-    console.warn(`[App] Failed to fetch files for ${repoId}@${revision}`, error);
-    return [];
-  }
-}
-
-function getAvailableQuantModes(files, baseName) {
-  const existing = new Set(files);
-  const options = QUANTIZATION_ORDER.filter((quant) => {
-    if (quant === 'fp32') return existing.has(`${baseName}.onnx`);
-    if (quant === 'fp16') return existing.has(`${baseName}.fp16.onnx`);
-    return existing.has(`${baseName}.int8.onnx`);
-  });
-  return options.length > 0 ? options : ['fp32'];
-}
-
-function pickPreferredQuant(available, currentBackend) {
-  const preferred = currentBackend.startsWith('webgpu')
-    ? ['fp16', 'fp32', 'int8']
-    : ['int8', 'fp32', 'fp16'];
-  return preferred.find((quant) => available.includes(quant)) || available[0] || 'fp32';
-}
 
 // Cache audio file from GitHub raw URL to IndexedDB
 async function getCachedAudioFile(url, cacheKey) {
@@ -180,20 +134,24 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 }
 
 export default function App() {
-  const [selectedModel, setSelectedModel] = useState('parakeet-tdt-0.6b-v2');
-  const [modelRevision, setModelRevision] = useState('main');
+  const initialSettings = loadSettings();
+  const initialSelectedModel = initialSettings.selectedModel;
+  const [selectedModel, setSelectedModel] = useState(
+    MODELS[initialSelectedModel] ? initialSelectedModel : 'parakeet-tdt-0.6b-v2'
+  );
+  const [modelRevision, setModelRevision] = useState(initialSettings.modelRevision || 'main');
   const [modelRevisions, setModelRevisions] = useState(DEFAULT_MODEL_REVISIONS);
   const modelConfig = MODELS[selectedModel];
-  const [selectedLanguage, setSelectedLanguage] = useState('en');
+  const [selectedLanguage, setSelectedLanguage] = useState(initialSettings.selectedLanguage || 'en');
   // Use hybrid mode by default (WebGPU encoder + WASM decoder)
-  const [backend, setBackend] = useState('webgpu-hybrid');
+  const [backend, setBackend] = useState(initialSettings.backend || 'webgpu-hybrid');
   const [threadingStatus, setThreadingStatus] = useState({ sab: false, threads: 1 });
-  const [encoderQuant, setEncoderQuant] = useState('int8');
-  const [decoderQuant, setDecoderQuant] = useState('int8');
+  const [encoderQuant, setEncoderQuant] = useState(initialSettings.encoderQuant || 'fp32');
+  const [decoderQuant, setDecoderQuant] = useState(initialSettings.decoderQuant || 'int8');
   const [encoderQuantOptions, setEncoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
   const [decoderQuantOptions, setDecoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
-  const [preprocessor, setPreprocessor] = useState('nemo128');
-  const [preprocessorBackend, setPreprocessorBackend] = useState('onnx');
+  const [preprocessor, setPreprocessor] = useState(initialSettings.preprocessor || 'nemo128');
+  const [preprocessorBackend, setPreprocessorBackend] = useState(initialSettings.preprocessorBackend || 'onnx');
   const [status, setStatus] = useState('Idle');
   const [progressText, setProgressText] = useState('');
   const [progressPct, setProgressPct] = useState(null);
@@ -203,17 +161,23 @@ export default function App() {
   const [transcriptions, setTranscriptions] = useState([]);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isLoadingSample, setIsLoadingSample] = useState(false);
-  const [verboseLog, setVerboseLog] = useState(false);
-  const [frameStride, setFrameStride] = useState(1);
-  const [dumpDetail, setDumpDetail] = useState(false);
-  const [enableProfiling, setEnableProfiling] = useState(true);
+  const [verboseLog, setVerboseLog] = useState(Boolean(initialSettings.verboseLog));
+  const [frameStride, setFrameStride] = useState(Number.isInteger(initialSettings.frameStride) ? initialSettings.frameStride : 1);
+  const [dumpDetail, setDumpDetail] = useState(Boolean(initialSettings.dumpDetail));
+  const [enableProfiling, setEnableProfiling] = useState(
+    initialSettings.enableProfiling === undefined ? true : Boolean(initialSettings.enableProfiling)
+  );
   const [audioUrl, setAudioUrl] = useState(null);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(Boolean(initialSettings.darkMode));
   const [modelLoaded, setModelLoaded] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
   const maxCores = navigator.hardwareConcurrency || 8;
-  const [cpuThreads, setCpuThreads] = useState(Math.max(1, maxCores - 2));
+  const [cpuThreads, setCpuThreads] = useState(
+    Number.isInteger(initialSettings.cpuThreads)
+      ? Math.min(maxCores, Math.max(1, initialSettings.cpuThreads))
+      : Math.max(1, maxCores - 2)
+  );
   const modelRef = useRef(null);
   const fileInputRef = useRef(null);
   const audioRef = useRef(null);
@@ -230,10 +194,10 @@ export default function App() {
   // Auto-adjust quant presets when backend changes (within available options).
   useEffect(() => {
     setEncoderQuant((current) =>
-      encoderQuantOptions.includes(current) ? current : pickPreferredQuant(encoderQuantOptions, backend)
+      encoderQuantOptions.includes(current) ? current : pickPreferredQuant(encoderQuantOptions, backend, 'encoder')
     );
     setDecoderQuant((current) =>
-      decoderQuantOptions.includes(current) ? current : pickPreferredQuant(decoderQuantOptions, backend)
+      decoderQuantOptions.includes(current) ? current : pickPreferredQuant(decoderQuantOptions, backend, 'decoder')
     );
   }, [backend, encoderQuantOptions, decoderQuantOptions]);
 
@@ -268,8 +232,12 @@ export default function App() {
       const decOptions = getAvailableQuantModes(files, 'decoder_joint-model');
       setEncoderQuantOptions(encOptions);
       setDecoderQuantOptions(decOptions);
-      setEncoderQuant((current) => (encOptions.includes(current) ? current : pickPreferredQuant(encOptions, backend)));
-      setDecoderQuant((current) => (decOptions.includes(current) ? current : pickPreferredQuant(decOptions, backend)));
+      setEncoderQuant((current) =>
+        encOptions.includes(current) ? current : pickPreferredQuant(encOptions, backend, 'encoder')
+      );
+      setDecoderQuant((current) =>
+        decOptions.includes(current) ? current : pickPreferredQuant(decOptions, backend, 'decoder')
+      );
     })();
 
     return () => {
@@ -283,6 +251,40 @@ export default function App() {
     const threads = sabAvailable ? (navigator.hardwareConcurrency || 1) : 1;
     setThreadingStatus({ sab: sabAvailable, threads });
   }, []);
+
+  useEffect(() => {
+    saveSettings({
+      selectedModel,
+      modelRevision,
+      selectedLanguage,
+      backend,
+      encoderQuant,
+      decoderQuant,
+      preprocessor,
+      preprocessorBackend,
+      verboseLog,
+      frameStride,
+      dumpDetail,
+      enableProfiling,
+      darkMode,
+      cpuThreads,
+    });
+  }, [
+    selectedModel,
+    modelRevision,
+    selectedLanguage,
+    backend,
+    encoderQuant,
+    decoderQuant,
+    preprocessor,
+    preprocessorBackend,
+    verboseLog,
+    frameStride,
+    dumpDetail,
+    enableProfiling,
+    darkMode,
+    cpuThreads,
+  ]);
 
   // Cleanup audio URL on unmount
   useEffect(() => {
@@ -403,30 +405,37 @@ export default function App() {
         setProgressPct(pct);
       };
 
-      const modelUrls = await getParakeetModel(selectedModel, {
-        revision: modelRevision,
-        encoderQuant,
-        decoderQuant,
-        preprocessor,
-        preprocessorBackend,
-        backend,
-        progress: progressCallback
-      });
-      const resolvedQuant = `Resolved quantization: encoder=${modelUrls.quantisation.encoder}, decoder=${modelUrls.quantisation.decoder}`;
-      console.log(`[App] ${resolvedQuant}`);
+      const modelLoadResult = await loadModelWithFallback({
+        repoIdOrModelKey: selectedModel,
+        options: {
+          revision: modelRevision,
+          encoderQuant,
+          decoderQuant,
+          preprocessor,
+          preprocessorBackend,
+          backend,
+          progress: progressCallback,
+          verbose: verboseLog,
+          cpuThreads,
+        },
+        getParakeetModelFn: getParakeetModel,
+        fromUrlsFn: ParakeetModel.fromUrls,
+        onBeforeCompile: ({ attempt, modelUrls }) => {
+          const resolvedQuant = formatResolvedQuantization(modelUrls.quantisation);
+          console.log(`[App] ${resolvedQuant}`);
 
-      setStatus('Compiling model…');
-      setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
-      setProgressPct(null);
-
-      modelRef.current = await ParakeetModel.fromUrls({
-        ...modelUrls.urls,
-        filenames: modelUrls.filenames,
-        preprocessorBackend,
-        backend,
-        verbose: verboseLog,
-        cpuThreads,
+          if (attempt === 2) {
+            setStatus('Retrying compile with FP32…');
+            setProgressText(`${resolvedQuant} · retrying after FP16 compile failure`);
+          } else {
+            setStatus('Compiling model…');
+            setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
+          }
+          setProgressPct(null);
+        },
       });
+
+      modelRef.current = modelLoadResult.model;
 
       setStatus('Verifying…');
       setProgressText('Running test transcription');
@@ -553,7 +562,7 @@ export default function App() {
             </div>
           </div>
           <button
-            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+            className="flex items-center justify-center p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
             onClick={() => setDarkMode(!darkMode)}
           >
             <span className="material-icons-outlined text-gray-600 dark:text-gray-300">

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -243,7 +243,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedModel, modelRevision, backend]);
+  }, [selectedModel, modelRevision]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -480,6 +480,8 @@ export default function App() {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    setText('');
+    setReferenceText('');
     setIsTranscribing(true);
     setStatus(`Transcribing "${file.name}"…`);
 

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -293,20 +293,6 @@ export default function App() {
     };
   }, [audioUrl]);
 
-  // On language change: stop playback and flush loaded sample
-  useEffect(() => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-    }
-    setIsPlaying(false);
-    if (audioUrl) {
-      URL.revokeObjectURL(audioUrl);
-      setAudioUrl(null);
-    }
-    setText('');
-    setReferenceText('');
-  }, [selectedLanguage]);
-
   // Toggle dark mode
   useEffect(() => {
     if (darkMode) {
@@ -328,6 +314,22 @@ export default function App() {
       audioRef.current.pause();
       setIsPlaying(false);
     }
+  }
+
+  function handleLanguageChange(nextLanguage) {
+    if (nextLanguage === selectedLanguage) return;
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+      setAudioUrl(null);
+    }
+    setText('');
+    setReferenceText('');
+    setSelectedLanguage(nextLanguage);
   }
 
   // Fetch random audio sample from HuggingFace speech dataset
@@ -885,7 +887,7 @@ export default function App() {
                   <div className="relative">
                     <select
                       value={selectedLanguage}
-                      onChange={e => setSelectedLanguage(e.target.value)}
+                      onChange={e => handleLanguageChange(e.target.value)}
                       disabled={!isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -151,8 +151,8 @@ export default function App() {
   // Auto-adjust quant presets when backend changes
   useEffect(() => {
     if (backend.startsWith('webgpu')) {
-      setEncoderQuant('fp32');
-      setDecoderQuant('int8');
+      setEncoderQuant('fp16');
+      setDecoderQuant('fp16');
     } else {
       setEncoderQuant('int8');
       setDecoderQuant('int8');
@@ -293,9 +293,11 @@ export default function App() {
         backend,
         progress: progressCallback
       });
+      const resolvedQuant = `Resolved quantization: encoder=${modelUrls.quantisation.encoder}, decoder=${modelUrls.quantisation.decoder}`;
+      console.log(`[App] ${resolvedQuant}`);
 
       setStatus('Compiling model…');
-      setProgressText('This may take ~10s on first load');
+      setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
       setProgressPct(null);
 
       modelRef.current = await ParakeetModel.fromUrls({
@@ -535,6 +537,7 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
+                      <option value="fp16">fp16</option>
                       <option value="fp32">fp32</option>
                       <option value="int8">int8</option>
                     </select>
@@ -556,6 +559,7 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
+                      <option value="fp16">fp16</option>
                       <option value="int8">int8</option>
                       <option value="fp32">fp32</option>
                     </select>

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -11,6 +11,12 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
   languages: config.languages,
 }));
 
+const MODEL_REVISIONS = [
+  'main',
+  'feat/fp16-canonical-v2',
+  'feat/fp16-canonical-v3',
+];
+
 // Cache audio file from GitHub raw URL to IndexedDB
 async function getCachedAudioFile(url, cacheKey) {
   const dbName = 'parakeet-demo-cache';
@@ -106,6 +112,7 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 
 export default function App() {
   const [selectedModel, setSelectedModel] = useState('parakeet-tdt-0.6b-v2');
+  const [modelRevision, setModelRevision] = useState('main');
   const modelConfig = MODELS[selectedModel];
   const [selectedLanguage, setSelectedLanguage] = useState('en');
   // Use hybrid mode by default (WebGPU encoder + WASM decoder)
@@ -286,6 +293,7 @@ export default function App() {
       };
 
       const modelUrls = await getParakeetModel(selectedModel, {
+        revision: modelRevision,
         encoderQuant,
         decoderQuant,
         preprocessor,
@@ -466,6 +474,28 @@ export default function App() {
                       {MODEL_OPTIONS.map(opt => (
                         <option key={opt.key} value={opt.key}>
                           {opt.displayName}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="material-icons-outlined absolute right-2 top-2 text-gray-400 pointer-events-none text-lg">
+                      expand_more
+                    </span>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                    Model Branch
+                  </label>
+                  <div className="relative">
+                    <select
+                      value={modelRevision}
+                      onChange={e => setModelRevision(e.target.value)}
+                      disabled={isLoading || isModelReady}
+                      className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
+                    >
+                      {MODEL_REVISIONS.map(rev => (
+                        <option key={rev} value={rev}>
+                          {rev}
                         </option>
                       ))}
                     </select>

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -352,6 +352,10 @@ export default function App() {
     setIsLoadingSample(true);
     setReferenceText('');
     setText('');
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
     if (audioUrl) {
       URL.revokeObjectURL(audioUrl);
       setAudioUrl(null);

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -293,6 +293,20 @@ export default function App() {
     };
   }, [audioUrl]);
 
+  // On language change: stop playback and flush loaded sample
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+      setAudioUrl(null);
+    }
+    setText('');
+    setReferenceText('');
+  }, [selectedLanguage]);
+
   // Toggle dark mode
   useEffect(() => {
     if (darkMode) {

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -13,6 +13,8 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
 
 const DEFAULT_MODEL_REVISIONS = ['main'];
 const MODEL_REVISIONS_CACHE = new Map();
+const MODEL_FILES_CACHE = new Map();
+const QUANTIZATION_ORDER = ['fp16', 'int8', 'fp32'];
 
 function formatRepoPath(repoId) {
   return repoId
@@ -42,6 +44,46 @@ async function fetchModelRevisions(repoId) {
     console.warn(`[App] Failed to fetch revisions for ${repoId}; using defaults`, error);
     return DEFAULT_MODEL_REVISIONS;
   }
+}
+
+async function fetchModelFiles(repoId, revision) {
+  if (!repoId) return [];
+  const cacheKey = `${repoId}@${revision}`;
+  if (MODEL_FILES_CACHE.has(cacheKey)) {
+    return MODEL_FILES_CACHE.get(cacheKey);
+  }
+
+  try {
+    const repoPath = formatRepoPath(repoId);
+    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/tree/${encodeURIComponent(revision)}?recursive=1`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    const files = Array.isArray(payload)
+      ? payload.filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string').map((entry) => entry.path)
+      : [];
+    MODEL_FILES_CACHE.set(cacheKey, files);
+    return files;
+  } catch (error) {
+    console.warn(`[App] Failed to fetch files for ${repoId}@${revision}`, error);
+    return [];
+  }
+}
+
+function getAvailableQuantModes(files, baseName) {
+  const existing = new Set(files);
+  const options = QUANTIZATION_ORDER.filter((quant) => {
+    if (quant === 'fp32') return existing.has(`${baseName}.onnx`);
+    if (quant === 'fp16') return existing.has(`${baseName}.fp16.onnx`);
+    return existing.has(`${baseName}.int8.onnx`);
+  });
+  return options.length > 0 ? options : ['fp32'];
+}
+
+function pickPreferredQuant(available, currentBackend) {
+  const preferred = currentBackend.startsWith('webgpu')
+    ? ['fp16', 'fp32', 'int8']
+    : ['int8', 'fp32', 'fp16'];
+  return preferred.find((quant) => available.includes(quant)) || available[0] || 'fp32';
 }
 
 // Cache audio file from GitHub raw URL to IndexedDB
@@ -148,6 +190,8 @@ export default function App() {
   const [threadingStatus, setThreadingStatus] = useState({ sab: false, threads: 1 });
   const [encoderQuant, setEncoderQuant] = useState('int8');
   const [decoderQuant, setDecoderQuant] = useState('int8');
+  const [encoderQuantOptions, setEncoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
+  const [decoderQuantOptions, setDecoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
   const [preprocessor, setPreprocessor] = useState('nemo128');
   const [preprocessorBackend, setPreprocessorBackend] = useState('onnx');
   const [status, setStatus] = useState('Idle');
@@ -183,16 +227,15 @@ export default function App() {
     displayName: config.displayName,
   }));
 
-  // Auto-adjust quant presets when backend changes
+  // Auto-adjust quant presets when backend changes (within available options).
   useEffect(() => {
-    if (backend.startsWith('webgpu')) {
-      setEncoderQuant('fp16');
-      setDecoderQuant('fp16');
-    } else {
-      setEncoderQuant('int8');
-      setDecoderQuant('int8');
-    }
-  }, [backend]);
+    setEncoderQuant((current) =>
+      encoderQuantOptions.includes(current) ? current : pickPreferredQuant(encoderQuantOptions, backend)
+    );
+    setDecoderQuant((current) =>
+      decoderQuantOptions.includes(current) ? current : pickPreferredQuant(decoderQuantOptions, backend)
+    );
+  }, [backend, encoderQuantOptions, decoderQuantOptions]);
 
   // List available branches for the selected model repo from HF refs API.
   useEffect(() => {
@@ -210,6 +253,29 @@ export default function App() {
       cancelled = true;
     };
   }, [selectedModel]);
+
+  // Inspect selected repo+branch files and filter quantization options accordingly.
+  useEffect(() => {
+    let cancelled = false;
+    const repoId = MODELS[selectedModel]?.repoId;
+    const revision = modelRevision || 'main';
+
+    (async () => {
+      const files = await fetchModelFiles(repoId, revision);
+      if (cancelled) return;
+
+      const encOptions = getAvailableQuantModes(files, 'encoder-model');
+      const decOptions = getAvailableQuantModes(files, 'decoder_joint-model');
+      setEncoderQuantOptions(encOptions);
+      setDecoderQuantOptions(decOptions);
+      setEncoderQuant((current) => (encOptions.includes(current) ? current : pickPreferredQuant(encOptions, backend)));
+      setDecoderQuant((current) => (decOptions.includes(current) ? current : pickPreferredQuant(decOptions, backend)));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedModel, modelRevision, backend]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -612,9 +678,9 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
-                      <option value="fp16">fp16</option>
-                      <option value="fp32">fp32</option>
-                      <option value="int8">int8</option>
+                      {encoderQuantOptions.map((quant) => (
+                        <option key={quant} value={quant}>{quant}</option>
+                      ))}
                     </select>
                     <span className="material-icons-outlined absolute right-2 top-2 text-gray-400 pointer-events-none text-lg">
                       expand_more
@@ -634,9 +700,9 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
-                      <option value="fp16">fp16</option>
-                      <option value="int8">int8</option>
-                      <option value="fp32">fp32</option>
+                      {decoderQuantOptions.map((quant) => (
+                        <option key={quant} value={quant}>{quant}</option>
+                      ))}
                     </select>
                     <span className="material-icons-outlined absolute right-2 top-2 text-gray-400 pointer-events-none text-lg">
                       expand_more

--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -223,6 +223,7 @@ export default function App() {
     let cancelled = false;
     const repoId = MODELS[selectedModel]?.repoId;
     const revision = modelRevision || 'main';
+    if (!modelRevisions.includes(revision)) return;
 
     (async () => {
       const files = await fetchModelFiles(repoId, revision);
@@ -243,7 +244,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedModel, modelRevision]);
+  }, [selectedModel, modelRevision, modelRevisions]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -330,6 +331,13 @@ export default function App() {
     setText('');
     setReferenceText('');
     setSelectedLanguage(nextLanguage);
+  }
+
+  function handleModelChange(nextModel) {
+    if (nextModel === selectedModel) return;
+    setSelectedModel(nextModel);
+    setModelRevisions(DEFAULT_MODEL_REVISIONS);
+    setModelRevision('main');
   }
 
   // Fetch random audio sample from HuggingFace speech dataset
@@ -605,7 +613,7 @@ export default function App() {
                   <div className="relative">
                     <select
                       value={selectedModel}
-                      onChange={e => setSelectedModel(e.target.value)}
+                      onChange={e => handleModelChange(e.target.value)}
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >

--- a/examples/demo/vite.config.js
+++ b/examples/demo/vite.config.js
@@ -49,8 +49,8 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
     fs: {
-      // Allow importing shared helpers from examples/shared.
-      allow: [path.resolve(__dirname, '../shared')],
+      // Allow serving this app root and shared helpers.
+      allow: [path.resolve(__dirname), path.resolve(__dirname, '../shared')],
     },
   },
   resolve: {

--- a/examples/demo/vite.config.js
+++ b/examples/demo/vite.config.js
@@ -50,7 +50,7 @@ export default defineConfig({
     },
     fs: {
       // Allow importing shared helpers from examples/shared.
-      allow: [path.resolve(__dirname, '..')],
+      allow: [path.resolve(__dirname, '../shared')],
     },
   },
   resolve: {

--- a/examples/demo/vite.config.js
+++ b/examples/demo/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
@@ -50,7 +50,11 @@ export default defineConfig({
     },
     fs: {
       // Allow serving this app root and shared helpers.
-      allow: [path.resolve(__dirname), path.resolve(__dirname, '../shared')],
+      allow: [
+        path.resolve(__dirname),
+        path.resolve(__dirname, '../shared'),
+        searchForWorkspaceRoot(process.cwd()),
+      ],
     },
   },
   resolve: {

--- a/examples/demo/vite.config.js
+++ b/examples/demo/vite.config.js
@@ -48,6 +48,10 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
+    fs: {
+      // Allow importing shared helpers from examples/shared.
+      allow: [path.resolve(__dirname, '..')],
+    },
   },
   resolve: {
     alias: useLocalSource ? {

--- a/examples/hf-spaces-demo/src/App.css
+++ b/examples/hf-spaces-demo/src/App.css
@@ -16,6 +16,18 @@
   background-color: #10b981;
 }
 
+/* Remove native select arrow so custom expand_more icon is the only one */
+select,
+select.appearance-none {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  background-image: none;
+}
+select::-ms-expand {
+  display: none;
+}
+
 /* Smooth transitions */
 input,
 select,

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -1,7 +1,36 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ParakeetModel, getParakeetModel, MODELS, LANGUAGE_NAMES } from 'parakeet.js';
 import { fetchRandomSample, hasTestSamples, SPEECH_DATASETS } from './utils/speechDatasets';
+import {
+  DEFAULT_MODEL_REVISIONS,
+  fetchModelRevisions,
+  fetchModelFiles,
+  getAvailableQuantModes,
+  pickPreferredQuant,
+} from '../../shared/modelSelection.js';
+import { formatResolvedQuantization, loadModelWithFallback } from '../../shared/modelLoader.js';
 import './App.css';
+
+const SETTINGS_STORAGE_KEY = 'parakeet.hf-spaces-demo.settings.v1';
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveSettings(settings) {
+  try {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore storage failures (private mode/quota).
+  }
+}
 
 // Available models for selection
 const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
@@ -10,81 +39,6 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
   displayName: config.displayName,
   languages: config.languages,
 }));
-
-const DEFAULT_MODEL_REVISIONS = ['main'];
-const MODEL_REVISIONS_CACHE = new Map();
-const MODEL_FILES_CACHE = new Map();
-const QUANTIZATION_ORDER = ['fp16', 'int8', 'fp32'];
-
-function formatRepoPath(repoId) {
-  return repoId
-    .split('/')
-    .map((part) => encodeURIComponent(part))
-    .join('/');
-}
-
-async function fetchModelRevisions(repoId) {
-  if (!repoId) return DEFAULT_MODEL_REVISIONS;
-  if (MODEL_REVISIONS_CACHE.has(repoId)) {
-    return MODEL_REVISIONS_CACHE.get(repoId);
-  }
-
-  try {
-    const repoPath = formatRepoPath(repoId);
-    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/refs`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json();
-    const branches = Array.isArray(payload?.branches)
-      ? payload.branches.map((branch) => branch?.name).filter(Boolean)
-      : [];
-    const revisions = branches.length > 0 ? branches : DEFAULT_MODEL_REVISIONS;
-    MODEL_REVISIONS_CACHE.set(repoId, revisions);
-    return revisions;
-  } catch (error) {
-    console.warn(`[App] Failed to fetch revisions for ${repoId}; using defaults`, error);
-    return DEFAULT_MODEL_REVISIONS;
-  }
-}
-
-async function fetchModelFiles(repoId, revision) {
-  if (!repoId) return [];
-  const cacheKey = `${repoId}@${revision}`;
-  if (MODEL_FILES_CACHE.has(cacheKey)) {
-    return MODEL_FILES_CACHE.get(cacheKey);
-  }
-
-  try {
-    const repoPath = formatRepoPath(repoId);
-    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/tree/${encodeURIComponent(revision)}?recursive=1`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json();
-    const files = Array.isArray(payload)
-      ? payload.filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string').map((entry) => entry.path)
-      : [];
-    MODEL_FILES_CACHE.set(cacheKey, files);
-    return files;
-  } catch (error) {
-    console.warn(`[App] Failed to fetch files for ${repoId}@${revision}`, error);
-    return [];
-  }
-}
-
-function getAvailableQuantModes(files, baseName) {
-  const existing = new Set(files);
-  const options = QUANTIZATION_ORDER.filter((quant) => {
-    if (quant === 'fp32') return existing.has(`${baseName}.onnx`);
-    if (quant === 'fp16') return existing.has(`${baseName}.fp16.onnx`);
-    return existing.has(`${baseName}.int8.onnx`);
-  });
-  return options.length > 0 ? options : ['fp32'];
-}
-
-function pickPreferredQuant(available, currentBackend) {
-  const preferred = currentBackend.startsWith('webgpu')
-    ? ['fp16', 'fp32', 'int8']
-    : ['int8', 'fp32', 'fp16'];
-  return preferred.find((quant) => available.includes(quant)) || available[0] || 'fp32';
-}
 
 // Cache audio file from GitHub raw URL to IndexedDB
 async function getCachedAudioFile(url, cacheKey) {
@@ -180,20 +134,24 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 }
 
 export default function App() {
-  const [selectedModel, setSelectedModel] = useState('parakeet-tdt-0.6b-v2');
-  const [modelRevision, setModelRevision] = useState('main');
+  const initialSettings = loadSettings();
+  const initialSelectedModel = initialSettings.selectedModel;
+  const [selectedModel, setSelectedModel] = useState(
+    MODELS[initialSelectedModel] ? initialSelectedModel : 'parakeet-tdt-0.6b-v2'
+  );
+  const [modelRevision, setModelRevision] = useState(initialSettings.modelRevision || 'main');
   const [modelRevisions, setModelRevisions] = useState(DEFAULT_MODEL_REVISIONS);
   const modelConfig = MODELS[selectedModel];
-  const [selectedLanguage, setSelectedLanguage] = useState('en');
+  const [selectedLanguage, setSelectedLanguage] = useState(initialSettings.selectedLanguage || 'en');
   // Use hybrid mode by default (WebGPU encoder + WASM decoder)
-  const [backend, setBackend] = useState('webgpu-hybrid');
+  const [backend, setBackend] = useState(initialSettings.backend || 'webgpu-hybrid');
   const [threadingStatus, setThreadingStatus] = useState({ sab: false, threads: 1 });
-  const [encoderQuant, setEncoderQuant] = useState('int8');
-  const [decoderQuant, setDecoderQuant] = useState('int8');
+  const [encoderQuant, setEncoderQuant] = useState(initialSettings.encoderQuant || 'fp32');
+  const [decoderQuant, setDecoderQuant] = useState(initialSettings.decoderQuant || 'int8');
   const [encoderQuantOptions, setEncoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
   const [decoderQuantOptions, setDecoderQuantOptions] = useState(['fp16', 'int8', 'fp32']);
-  const [preprocessor, setPreprocessor] = useState('nemo128');
-  const [preprocessorBackend, setPreprocessorBackend] = useState('onnx');
+  const [preprocessor, setPreprocessor] = useState(initialSettings.preprocessor || 'nemo128');
+  const [preprocessorBackend, setPreprocessorBackend] = useState(initialSettings.preprocessorBackend || 'onnx');
   const [status, setStatus] = useState('Idle');
   const [progressText, setProgressText] = useState('');
   const [progressPct, setProgressPct] = useState(null);
@@ -203,17 +161,23 @@ export default function App() {
   const [transcriptions, setTranscriptions] = useState([]);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isLoadingSample, setIsLoadingSample] = useState(false);
-  const [verboseLog, setVerboseLog] = useState(false);
-  const [frameStride, setFrameStride] = useState(1);
-  const [dumpDetail, setDumpDetail] = useState(false);
-  const [enableProfiling, setEnableProfiling] = useState(true);
+  const [verboseLog, setVerboseLog] = useState(Boolean(initialSettings.verboseLog));
+  const [frameStride, setFrameStride] = useState(Number.isInteger(initialSettings.frameStride) ? initialSettings.frameStride : 1);
+  const [dumpDetail, setDumpDetail] = useState(Boolean(initialSettings.dumpDetail));
+  const [enableProfiling, setEnableProfiling] = useState(
+    initialSettings.enableProfiling === undefined ? true : Boolean(initialSettings.enableProfiling)
+  );
   const [audioUrl, setAudioUrl] = useState(null);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(Boolean(initialSettings.darkMode));
   const [modelLoaded, setModelLoaded] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
   const maxCores = navigator.hardwareConcurrency || 8;
-  const [cpuThreads, setCpuThreads] = useState(Math.max(1, maxCores - 2));
+  const [cpuThreads, setCpuThreads] = useState(
+    Number.isInteger(initialSettings.cpuThreads)
+      ? Math.min(maxCores, Math.max(1, initialSettings.cpuThreads))
+      : Math.max(1, maxCores - 2)
+  );
   const modelRef = useRef(null);
   const fileInputRef = useRef(null);
   const audioRef = useRef(null);
@@ -230,10 +194,10 @@ export default function App() {
   // Auto-adjust quant presets when backend changes (within available options).
   useEffect(() => {
     setEncoderQuant((current) =>
-      encoderQuantOptions.includes(current) ? current : pickPreferredQuant(encoderQuantOptions, backend)
+      encoderQuantOptions.includes(current) ? current : pickPreferredQuant(encoderQuantOptions, backend, 'encoder')
     );
     setDecoderQuant((current) =>
-      decoderQuantOptions.includes(current) ? current : pickPreferredQuant(decoderQuantOptions, backend)
+      decoderQuantOptions.includes(current) ? current : pickPreferredQuant(decoderQuantOptions, backend, 'decoder')
     );
   }, [backend, encoderQuantOptions, decoderQuantOptions]);
 
@@ -268,8 +232,12 @@ export default function App() {
       const decOptions = getAvailableQuantModes(files, 'decoder_joint-model');
       setEncoderQuantOptions(encOptions);
       setDecoderQuantOptions(decOptions);
-      setEncoderQuant((current) => (encOptions.includes(current) ? current : pickPreferredQuant(encOptions, backend)));
-      setDecoderQuant((current) => (decOptions.includes(current) ? current : pickPreferredQuant(decOptions, backend)));
+      setEncoderQuant((current) =>
+        encOptions.includes(current) ? current : pickPreferredQuant(encOptions, backend, 'encoder')
+      );
+      setDecoderQuant((current) =>
+        decOptions.includes(current) ? current : pickPreferredQuant(decOptions, backend, 'decoder')
+      );
     })();
 
     return () => {
@@ -283,6 +251,40 @@ export default function App() {
     const threads = sabAvailable ? (navigator.hardwareConcurrency || 1) : 1;
     setThreadingStatus({ sab: sabAvailable, threads });
   }, []);
+
+  useEffect(() => {
+    saveSettings({
+      selectedModel,
+      modelRevision,
+      selectedLanguage,
+      backend,
+      encoderQuant,
+      decoderQuant,
+      preprocessor,
+      preprocessorBackend,
+      verboseLog,
+      frameStride,
+      dumpDetail,
+      enableProfiling,
+      darkMode,
+      cpuThreads,
+    });
+  }, [
+    selectedModel,
+    modelRevision,
+    selectedLanguage,
+    backend,
+    encoderQuant,
+    decoderQuant,
+    preprocessor,
+    preprocessorBackend,
+    verboseLog,
+    frameStride,
+    dumpDetail,
+    enableProfiling,
+    darkMode,
+    cpuThreads,
+  ]);
 
   // Cleanup audio URL on unmount
   useEffect(() => {
@@ -403,30 +405,37 @@ export default function App() {
         setProgressPct(pct);
       };
 
-      const modelUrls = await getParakeetModel(selectedModel, {
-        revision: modelRevision,
-        encoderQuant,
-        decoderQuant,
-        preprocessor,
-        preprocessorBackend,
-        backend,
-        progress: progressCallback
-      });
-      const resolvedQuant = `Resolved quantization: encoder=${modelUrls.quantisation.encoder}, decoder=${modelUrls.quantisation.decoder}`;
-      console.log(`[App] ${resolvedQuant}`);
+      const modelLoadResult = await loadModelWithFallback({
+        repoIdOrModelKey: selectedModel,
+        options: {
+          revision: modelRevision,
+          encoderQuant,
+          decoderQuant,
+          preprocessor,
+          preprocessorBackend,
+          backend,
+          progress: progressCallback,
+          verbose: verboseLog,
+          cpuThreads,
+        },
+        getParakeetModelFn: getParakeetModel,
+        fromUrlsFn: ParakeetModel.fromUrls,
+        onBeforeCompile: ({ attempt, modelUrls }) => {
+          const resolvedQuant = formatResolvedQuantization(modelUrls.quantisation);
+          console.log(`[App] ${resolvedQuant}`);
 
-      setStatus('Compiling model…');
-      setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
-      setProgressPct(null);
-
-      modelRef.current = await ParakeetModel.fromUrls({
-        ...modelUrls.urls,
-        filenames: modelUrls.filenames,
-        preprocessorBackend,
-        backend,
-        verbose: verboseLog,
-        cpuThreads,
+          if (attempt === 2) {
+            setStatus('Retrying compile with FP32…');
+            setProgressText(`${resolvedQuant} · retrying after FP16 compile failure`);
+          } else {
+            setStatus('Compiling model…');
+            setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
+          }
+          setProgressPct(null);
+        },
       });
+
+      modelRef.current = modelLoadResult.model;
 
       setStatus('Verifying…');
       setProgressText('Running test transcription');
@@ -572,7 +581,7 @@ export default function App() {
             </div>
           </div>
           <button
-            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+            className="flex items-center justify-center p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
             onClick={() => setDarkMode(!darkMode)}
           >
             <span className="material-icons-outlined text-gray-600 dark:text-gray-300">

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -243,7 +243,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedModel, modelRevision, backend]);
+  }, [selectedModel, modelRevision]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -480,6 +480,8 @@ export default function App() {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    setText('');
+    setReferenceText('');
     setIsTranscribing(true);
     setStatus(`Transcribing "${file.name}"…`);
 

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -11,6 +11,12 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
   languages: config.languages,
 }));
 
+const MODEL_REVISIONS = [
+  'main',
+  'feat/fp16-canonical-v2',
+  'feat/fp16-canonical-v3',
+];
+
 // Cache audio file from GitHub raw URL to IndexedDB
 async function getCachedAudioFile(url, cacheKey) {
   const dbName = 'parakeet-demo-cache';
@@ -106,6 +112,7 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 
 export default function App() {
   const [selectedModel, setSelectedModel] = useState('parakeet-tdt-0.6b-v2');
+  const [modelRevision, setModelRevision] = useState('main');
   const modelConfig = MODELS[selectedModel];
   const [selectedLanguage, setSelectedLanguage] = useState('en');
   // Use hybrid mode by default (WebGPU encoder + WASM decoder)
@@ -286,6 +293,7 @@ export default function App() {
       };
 
       const modelUrls = await getParakeetModel(selectedModel, {
+        revision: modelRevision,
         encoderQuant,
         decoderQuant,
         preprocessor,
@@ -485,6 +493,28 @@ export default function App() {
                       {MODEL_OPTIONS.map(opt => (
                         <option key={opt.key} value={opt.key}>
                           {opt.displayName}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="material-icons-outlined absolute right-2 top-2 text-gray-400 pointer-events-none text-lg">
+                      expand_more
+                    </span>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                    Model Branch
+                  </label>
+                  <div className="relative">
+                    <select
+                      value={modelRevision}
+                      onChange={e => setModelRevision(e.target.value)}
+                      disabled={isLoading || isModelReady}
+                      className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
+                    >
+                      {MODEL_REVISIONS.map(rev => (
+                        <option key={rev} value={rev}>
+                          {rev}
                         </option>
                       ))}
                     </select>

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -151,8 +151,8 @@ export default function App() {
   // Auto-adjust quant presets when backend changes
   useEffect(() => {
     if (backend.startsWith('webgpu')) {
-      setEncoderQuant('fp32');
-      setDecoderQuant('int8');
+      setEncoderQuant('fp16');
+      setDecoderQuant('fp16');
     } else {
       setEncoderQuant('int8');
       setDecoderQuant('int8');
@@ -293,9 +293,11 @@ export default function App() {
         backend,
         progress: progressCallback
       });
+      const resolvedQuant = `Resolved quantization: encoder=${modelUrls.quantisation.encoder}, decoder=${modelUrls.quantisation.decoder}`;
+      console.log(`[App] ${resolvedQuant}`);
 
       setStatus('Compiling model…');
-      setProgressText('This may take ~10s on first load');
+      setProgressText(`${resolvedQuant} · compiling may take ~10s on first load`);
       setProgressPct(null);
 
       modelRef.current = await ParakeetModel.fromUrls({
@@ -554,6 +556,7 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
+                      <option value="fp16">fp16</option>
                       <option value="fp32">fp32</option>
                       <option value="int8">int8</option>
                     </select>
@@ -575,6 +578,7 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
+                      <option value="fp16">fp16</option>
                       <option value="int8">int8</option>
                       <option value="fp32">fp32</option>
                     </select>

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -223,6 +223,7 @@ export default function App() {
     let cancelled = false;
     const repoId = MODELS[selectedModel]?.repoId;
     const revision = modelRevision || 'main';
+    if (!modelRevisions.includes(revision)) return;
 
     (async () => {
       const files = await fetchModelFiles(repoId, revision);
@@ -243,7 +244,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedModel, modelRevision]);
+  }, [selectedModel, modelRevision, modelRevisions]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -330,6 +331,13 @@ export default function App() {
     setText('');
     setReferenceText('');
     setSelectedLanguage(nextLanguage);
+  }
+
+  function handleModelChange(nextModel) {
+    if (nextModel === selectedModel) return;
+    setSelectedModel(nextModel);
+    setModelRevisions(DEFAULT_MODEL_REVISIONS);
+    setModelRevision('main');
   }
 
   // Fetch random audio sample from HuggingFace speech dataset
@@ -624,7 +632,7 @@ export default function App() {
                   <div className="relative">
                     <select
                       value={selectedModel}
-                      onChange={e => setSelectedModel(e.target.value)}
+                      onChange={e => handleModelChange(e.target.value)}
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -293,20 +293,6 @@ export default function App() {
     };
   }, [audioUrl]);
 
-  // On language change: stop playback and flush loaded sample
-  useEffect(() => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-    }
-    setIsPlaying(false);
-    if (audioUrl) {
-      URL.revokeObjectURL(audioUrl);
-      setAudioUrl(null);
-    }
-    setText('');
-    setReferenceText('');
-  }, [selectedLanguage]);
-
   // Toggle dark mode
   useEffect(() => {
     if (darkMode) {
@@ -328,6 +314,22 @@ export default function App() {
       audioRef.current.pause();
       setIsPlaying(false);
     }
+  }
+
+  function handleLanguageChange(nextLanguage) {
+    if (nextLanguage === selectedLanguage) return;
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+      setAudioUrl(null);
+    }
+    setText('');
+    setReferenceText('');
+    setSelectedLanguage(nextLanguage);
   }
 
   // Fetch random audio sample from HuggingFace speech dataset
@@ -904,7 +906,7 @@ export default function App() {
                   <div className="relative">
                     <select
                       value={selectedLanguage}
-                      onChange={e => setSelectedLanguage(e.target.value)}
+                      onChange={e => handleLanguageChange(e.target.value)}
                       disabled={!isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -352,6 +352,10 @@ export default function App() {
     setIsLoadingSample(true);
     setReferenceText('');
     setText('');
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
     if (audioUrl) {
       URL.revokeObjectURL(audioUrl);
       setAudioUrl(null);

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -293,6 +293,20 @@ export default function App() {
     };
   }, [audioUrl]);
 
+  // On language change: stop playback and flush loaded sample
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    setIsPlaying(false);
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+      setAudioUrl(null);
+    }
+    setText('');
+    setReferenceText('');
+  }, [selectedLanguage]);
+
   // Toggle dark mode
   useEffect(() => {
     if (darkMode) {

--- a/examples/hf-spaces-demo/src/App.jsx
+++ b/examples/hf-spaces-demo/src/App.jsx
@@ -11,11 +11,38 @@ const MODEL_OPTIONS = Object.entries(MODELS).map(([key, config]) => ({
   languages: config.languages,
 }));
 
-const MODEL_REVISIONS = [
-  'main',
-  'feat/fp16-canonical-v2',
-  'feat/fp16-canonical-v3',
-];
+const DEFAULT_MODEL_REVISIONS = ['main'];
+const MODEL_REVISIONS_CACHE = new Map();
+
+function formatRepoPath(repoId) {
+  return repoId
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+}
+
+async function fetchModelRevisions(repoId) {
+  if (!repoId) return DEFAULT_MODEL_REVISIONS;
+  if (MODEL_REVISIONS_CACHE.has(repoId)) {
+    return MODEL_REVISIONS_CACHE.get(repoId);
+  }
+
+  try {
+    const repoPath = formatRepoPath(repoId);
+    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/refs`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    const branches = Array.isArray(payload?.branches)
+      ? payload.branches.map((branch) => branch?.name).filter(Boolean)
+      : [];
+    const revisions = branches.length > 0 ? branches : DEFAULT_MODEL_REVISIONS;
+    MODEL_REVISIONS_CACHE.set(repoId, revisions);
+    return revisions;
+  } catch (error) {
+    console.warn(`[App] Failed to fetch revisions for ${repoId}; using defaults`, error);
+    return DEFAULT_MODEL_REVISIONS;
+  }
+}
 
 // Cache audio file from GitHub raw URL to IndexedDB
 async function getCachedAudioFile(url, cacheKey) {
@@ -113,6 +140,7 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 export default function App() {
   const [selectedModel, setSelectedModel] = useState('parakeet-tdt-0.6b-v2');
   const [modelRevision, setModelRevision] = useState('main');
+  const [modelRevisions, setModelRevisions] = useState(DEFAULT_MODEL_REVISIONS);
   const modelConfig = MODELS[selectedModel];
   const [selectedLanguage, setSelectedLanguage] = useState('en');
   // Use hybrid mode by default (WebGPU encoder + WASM decoder)
@@ -165,6 +193,23 @@ export default function App() {
       setDecoderQuant('int8');
     }
   }, [backend]);
+
+  // List available branches for the selected model repo from HF refs API.
+  useEffect(() => {
+    let cancelled = false;
+    const repoId = MODELS[selectedModel]?.repoId;
+
+    (async () => {
+      const revisions = await fetchModelRevisions(repoId);
+      if (cancelled) return;
+      setModelRevisions(revisions);
+      setModelRevision((current) => (revisions.includes(current) ? current : revisions[0] || 'main'));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedModel]);
 
   // Detect SharedArrayBuffer and threading capabilities
   useEffect(() => {
@@ -512,7 +557,7 @@ export default function App() {
                       disabled={isLoading || isModelReady}
                       className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:ring-primary focus:border-primary dark:text-white appearance-none"
                     >
-                      {MODEL_REVISIONS.map(rev => (
+                      {modelRevisions.map(rev => (
                         <option key={rev} value={rev}>
                           {rev}
                         </option>

--- a/examples/hf-spaces-demo/vite.config.js
+++ b/examples/hf-spaces-demo/vite.config.js
@@ -36,7 +36,7 @@ export default defineConfig({
     },
     fs: {
       // Allow importing shared helpers from examples/shared.
-      allow: [path.resolve(__dirname, '..')],
+      allow: [path.resolve(__dirname, '../shared')],
     },
   },
   resolve: {

--- a/examples/hf-spaces-demo/vite.config.js
+++ b/examples/hf-spaces-demo/vite.config.js
@@ -34,6 +34,10 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
+    fs: {
+      // Allow importing shared helpers from examples/shared.
+      allow: [path.resolve(__dirname, '..')],
+    },
   },
   resolve: {
     alias: useLocalSource ? {

--- a/examples/hf-spaces-demo/vite.config.js
+++ b/examples/hf-spaces-demo/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
@@ -36,7 +36,11 @@ export default defineConfig({
     },
     fs: {
       // Allow serving this app root and shared helpers.
-      allow: [path.resolve(__dirname), path.resolve(__dirname, '../shared')],
+      allow: [
+        path.resolve(__dirname),
+        path.resolve(__dirname, '../shared'),
+        searchForWorkspaceRoot(process.cwd()),
+      ],
     },
   },
   resolve: {

--- a/examples/hf-spaces-demo/vite.config.js
+++ b/examples/hf-spaces-demo/vite.config.js
@@ -35,8 +35,8 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
     fs: {
-      // Allow importing shared helpers from examples/shared.
-      allow: [path.resolve(__dirname, '../shared')],
+      // Allow serving this app root and shared helpers.
+      allow: [path.resolve(__dirname), path.resolve(__dirname, '../shared')],
     },
   },
   resolve: {

--- a/examples/shared/modelLoader.js
+++ b/examples/shared/modelLoader.js
@@ -1,0 +1,69 @@
+export function formatResolvedQuantization(quantisation) {
+  return `Resolved quantization: encoder=${quantisation.encoder}, decoder=${quantisation.decoder}`;
+}
+
+function toFromUrlsConfig(modelUrls, options) {
+  return {
+    ...modelUrls.urls,
+    filenames: modelUrls.filenames,
+    preprocessorBackend: modelUrls.preprocessorBackend,
+    ...options,
+  };
+}
+
+function shouldRetryWithFp32(quantisation) {
+  return quantisation?.encoder === 'fp16' || quantisation?.decoder === 'fp16';
+}
+
+function buildRetryOptions(options, quantisation) {
+  const retryOptions = { ...options };
+  if (quantisation?.encoder === 'fp16') retryOptions.encoderQuant = 'fp32';
+  if (quantisation?.decoder === 'fp16') retryOptions.decoderQuant = 'fp32';
+  return retryOptions;
+}
+
+/**
+ * Resolve model assets from hub and compile with one FP16 -> FP32 runtime retry.
+ *
+ * @param {Object} params
+ * @param {string} params.repoIdOrModelKey
+ * @param {Object} params.options
+ * @param {(repoIdOrModelKey: string, options: Object) => Promise<any>} params.getParakeetModelFn
+ * @param {(cfg: Object) => Promise<any>} params.fromUrlsFn
+ * @param {(ctx: {attempt: number, modelUrls: any, options: Object}) => void} [params.onBeforeCompile]
+ * @returns {Promise<{model: any, modelUrls: any, retryUsed: boolean}>}
+ */
+export async function loadModelWithFallback({
+  repoIdOrModelKey,
+  options,
+  getParakeetModelFn,
+  fromUrlsFn,
+  onBeforeCompile,
+}) {
+  const firstModelUrls = await getParakeetModelFn(repoIdOrModelKey, options);
+  onBeforeCompile?.({ attempt: 1, modelUrls: firstModelUrls, options });
+
+  try {
+    const model = await fromUrlsFn(toFromUrlsConfig(firstModelUrls, options));
+    return { model, modelUrls: firstModelUrls, retryUsed: false };
+  } catch (firstError) {
+    if (!shouldRetryWithFp32(firstModelUrls.quantisation)) {
+      throw firstError;
+    }
+
+    const retryOptions = buildRetryOptions(options, firstModelUrls.quantisation);
+    const retryModelUrls = await getParakeetModelFn(repoIdOrModelKey, retryOptions);
+    onBeforeCompile?.({ attempt: 2, modelUrls: retryModelUrls, options: retryOptions });
+
+    try {
+      const model = await fromUrlsFn(toFromUrlsConfig(retryModelUrls, retryOptions));
+      return { model, modelUrls: retryModelUrls, retryUsed: true };
+    } catch (retryError) {
+      const firstMessage = firstError?.message || String(firstError);
+      const retryMessage = retryError?.message || String(retryError);
+      throw new Error(
+        `[ModelLoader] Initial compile failed (${firstMessage}). FP32 retry also failed (${retryMessage}).`
+      );
+    }
+  }
+}

--- a/examples/shared/modelSelection.js
+++ b/examples/shared/modelSelection.js
@@ -1,0 +1,117 @@
+export const DEFAULT_MODEL_REVISIONS = ['main'];
+export const QUANTIZATION_ORDER = ['fp16', 'int8', 'fp32'];
+
+const MODEL_REVISIONS_CACHE = new Map();
+const MODEL_FILES_CACHE = new Map();
+
+export function formatRepoPath(repoId) {
+  return String(repoId || '')
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+}
+
+function normalizePath(path) {
+  return String(path || '').replace(/^\.\/+/, '').replace(/\\/g, '/');
+}
+
+function parseModelFiles(payload) {
+  if (Array.isArray(payload)) {
+    return payload
+      .filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string')
+      .map((entry) => normalizePath(entry.path));
+  }
+
+  if (payload && typeof payload === 'object' && Array.isArray(payload.siblings)) {
+    return payload.siblings
+      .map((entry) => normalizePath(entry?.rfilename))
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function hasFile(files, filename) {
+  const target = normalizePath(filename);
+  return files.some((path) => path === target || path.endsWith(`/${target}`));
+}
+
+export async function fetchModelRevisions(repoId) {
+  if (!repoId) return DEFAULT_MODEL_REVISIONS;
+  if (MODEL_REVISIONS_CACHE.has(repoId)) {
+    return MODEL_REVISIONS_CACHE.get(repoId);
+  }
+
+  try {
+    const repoPath = formatRepoPath(repoId);
+    const response = await fetch(`https://huggingface.co/api/models/${repoPath}/refs`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    const branches = Array.isArray(payload?.branches)
+      ? payload.branches.map((branch) => branch?.name).filter(Boolean)
+      : [];
+    const revisions = branches.length > 0 ? branches : DEFAULT_MODEL_REVISIONS;
+    MODEL_REVISIONS_CACHE.set(repoId, revisions);
+    return revisions;
+  } catch (error) {
+    console.warn(`[modelSelection] Failed to fetch revisions for ${repoId}; using defaults`, error);
+    return DEFAULT_MODEL_REVISIONS;
+  }
+}
+
+export async function fetchModelFiles(repoId, revision = 'main') {
+  if (!repoId) return [];
+  const cacheKey = `${repoId}@${revision}`;
+  if (MODEL_FILES_CACHE.has(cacheKey)) {
+    return MODEL_FILES_CACHE.get(cacheKey);
+  }
+
+  const repoPath = formatRepoPath(repoId);
+  const encodedRevision = encodeURIComponent(revision);
+  const treeUrl = `https://huggingface.co/api/models/${repoPath}/tree/${encodedRevision}?recursive=1`;
+  const metadataUrl = `https://huggingface.co/api/models/${repoPath}?revision=${encodedRevision}`;
+
+  try {
+    const response = await fetch(treeUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const files = parseModelFiles(await response.json());
+    MODEL_FILES_CACHE.set(cacheKey, files);
+    return files;
+  } catch (treeError) {
+    console.warn(`[modelSelection] Tree listing failed for ${repoId}@${revision}; trying metadata`, treeError);
+  }
+
+  try {
+    const response = await fetch(metadataUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const files = parseModelFiles(await response.json());
+    MODEL_FILES_CACHE.set(cacheKey, files);
+    return files;
+  } catch (metadataError) {
+    console.warn(`[modelSelection] Metadata listing failed for ${repoId}@${revision}`, metadataError);
+    return [];
+  }
+}
+
+export function getAvailableQuantModes(files, baseName) {
+  const options = QUANTIZATION_ORDER.filter((quant) => {
+    if (quant === 'fp32') return hasFile(files, `${baseName}.onnx`);
+    if (quant === 'fp16') return hasFile(files, `${baseName}.fp16.onnx`);
+    return hasFile(files, `${baseName}.int8.onnx`);
+  });
+  return options.length > 0 ? options : ['fp32'];
+}
+
+export function pickPreferredQuant(available, currentBackend, component = 'encoder') {
+  let preferred;
+
+  if (component === 'decoder') {
+    preferred = ['int8', 'fp32', 'fp16'];
+  } else {
+    preferred = String(currentBackend || '').startsWith('webgpu')
+      ? ['fp16', 'fp32', 'int8']
+      : ['int8', 'fp32', 'fp16'];
+  }
+
+  return preferred.find((quant) => available.includes(quant)) || available[0] || 'fp32';
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "NVIDIA Parakeet speech recognition for the browser (WebGPU/WASM) powered by ONNX Runtime Web.",
   "type": "module",
   "types": "./types/index.d.ts",

--- a/src/hub.js
+++ b/src/hub.js
@@ -347,7 +347,11 @@ function validateRequestedFp16Component(component, repoId, repoFiles) {
  * @param {'nemo80'|'nemo128'} preprocessor
  * @returns {Array<{key: string, name: string, componentName?: 'encoder'|'decoder', optional?: boolean}>}
  */
-function buildRequiredDownloads(components, preprocessorBackend, preprocessor, verbose = false) {
+ * @param {{encoder: ResolvedComponent, decoder: ResolvedComponent}} components
+ * @param {'js'|'onnx'} preprocessorBackend
+ * @param {'nemo80'|'nemo128'} preprocessor
+ * @param {boolean} [verbose=false] Whether to log preprocessor selection.
+ * @returns {Array<{key: string, name: string, componentName?: 'encoder'|'decoder', optional?: boolean}>}
   const files = [
     {
       key: components.encoder.key,

--- a/src/hub.js
+++ b/src/hub.js
@@ -18,6 +18,11 @@ const QUANT_SUFFIX = {
   fp32: '.onnx',
 };
 
+/**
+ * @param {string} baseName - Base filename (e.g. 'encoder-model').
+ * @param {('int8'|'fp32'|'fp16')} quant - Quantization key.
+ * @returns {string} Filename with quant suffix (e.g. 'encoder-model.fp16.onnx').
+ */
 function getQuantizedModelName(baseName, quant) {
   return `${baseName}${QUANT_SUFFIX[quant] || QUANT_SUFFIX.fp32}`;
 }

--- a/src/hub.js
+++ b/src/hub.js
@@ -379,7 +379,8 @@ function buildOptionalExternalDataDownloads(components, repoFiles) {
     { key: 'decoderDataUrl', name: `${components.decoder.filename}.data`, optional: true },
   ];
 
-  if (repoFiles === null) return candidates;
+  // When listing is unavailable, skip optimistic .data fetches to avoid extra 404 round-trips.
+  if (repoFiles === null) return [];
   return candidates.filter((entry) => repoHasFile(repoFiles, entry.name));
 }
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -3,15 +3,17 @@
  * Downloads models from HF and caches them in browser storage.
  */
 
-import { MODELS, getModelConfig } from './models.js';
+import { getModelConfig } from './models.js';
 /** @typedef {import('./models.js').ModelConfig} ModelConfig */
 
 const DB_NAME = 'parakeet-cache-db';
 const STORE_NAME = 'file-store';
 let dbPromise = null;
 
-// Cache for repo file listings so we only hit the HF API once per page load
+// Cache for repo file listings so we only hit the HF API once per page load.
+// Cache successful lookups only. Failed lookups intentionally do not cache.
 const repoFileCache = new Map();
+
 const QUANT_SUFFIX = {
   int8: '.int8.onnx',
   fp16: '.fp16.onnx',
@@ -28,10 +30,58 @@ function getQuantizedModelName(baseName, quant) {
 }
 
 /**
+ * Normalize HF tree/metadata path entry.
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizeRepoPath(path) {
+  if (typeof path !== 'string') return '';
+  const normalized = path.replace(/^\.\//, '').replace(/\\/g, '/');
+  return normalized;
+}
+
+/**
+ * Parse file listing payload from HF tree or metadata endpoints.
+ * @param {unknown} payload
+ * @returns {string[]}
+ */
+function parseRepoListingPayload(payload) {
+  if (Array.isArray(payload)) {
+    return payload
+      .filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string')
+      .map((entry) => normalizeRepoPath(entry.path));
+  }
+
+  if (payload && typeof payload === 'object' && Array.isArray(payload.siblings)) {
+    return payload.siblings
+      .map((entry) => normalizeRepoPath(entry?.rfilename))
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+/**
+ * Whether a listing contains a given filename at repo root or in nested path.
+ * @param {string[]|null} repoFiles
+ * @param {string} filename
+ * @returns {boolean}
+ */
+function repoHasFile(repoFiles, filename) {
+  if (!repoFiles) return false;
+  const target = normalizeRepoPath(filename);
+  return repoFiles.some((path) => path === target || path.endsWith(`/${target}`));
+}
+
+/**
  * List model repository files from the Hugging Face model API.
+ *
+ * Returns `null` when listing is unavailable (network/API failure), which is
+ * distinct from an empty successful listing (`[]`).
+ *
  * @param {string} repoId - Hugging Face repository ID.
  * @param {string} [revision='main'] - Git revision/branch/tag.
- * @returns {Promise<string[]>} Repository file paths.
+ * @returns {Promise<string[]|null>} Repository file paths, or `null` if listing could not be obtained.
  */
 async function listRepoFiles(repoId, revision = 'main') {
   const cacheKey = `${repoId}@${revision}`;
@@ -40,36 +90,26 @@ async function listRepoFiles(repoId, revision = 'main') {
   const encodedRevision = encodeURIComponent(revision);
   const treeUrl = `https://huggingface.co/api/models/${repoId}/tree/${encodedRevision}?recursive=1`;
   const modelUrl = `https://huggingface.co/api/models/${repoId}?revision=${encodedRevision}`;
+
   try {
     const resp = await fetch(treeUrl);
-    if (!resp.ok) throw new Error(`Failed to list repo files: ${resp.status}`);
-    const json = await resp.json();
-    let files = [];
-    if (Array.isArray(json)) {
-      files = json
-        .filter((entry) => entry?.type === 'file' && typeof entry?.path === 'string')
-        .map((entry) => entry.path);
-    } else {
-      // Backward-compatible fallback for mocked/legacy response shape.
-      files = json.siblings?.map((s) => s.rfilename) || [];
-    }
+    if (!resp.ok) throw new Error(`Failed to list repo files from tree API: ${resp.status}`);
+    const files = parseRepoListingPayload(await resp.json());
     repoFileCache.set(cacheKey, files);
     return files;
-  } catch (err) {
-    console.warn('[Hub] Could not fetch repo tree listing; trying model metadata listing', err);
-    try {
-      const resp = await fetch(modelUrl);
-      if (!resp.ok) throw new Error(`Failed to list repo files: ${resp.status}`);
-      const json = await resp.json();
-      const files = json.siblings?.map((s) => s.rfilename) || [];
-      repoFileCache.set(cacheKey, files);
-      return files;
-    } catch (fallbackErr) {
-      console.warn('[Hub] Could not fetch repo file list – falling back to optimistic fetch', fallbackErr);
-      // Return empty list so caller behaves like old code (may attempt fetch and catch 404)
-      repoFileCache.set(cacheKey, []);
-      return [];
-    }
+  } catch (treeErr) {
+    console.warn('[Hub] Could not fetch repo tree listing; trying model metadata listing', treeErr);
+  }
+
+  try {
+    const resp = await fetch(modelUrl);
+    if (!resp.ok) throw new Error(`Failed to list repo files from metadata API: ${resp.status}`);
+    const files = parseRepoListingPayload(await resp.json());
+    repoFileCache.set(cacheKey, files);
+    return files;
+  } catch (metadataErr) {
+    console.warn('[Hub] Could not fetch repo file list – falling back to optimistic fetch', metadataErr);
+    return null;
   }
 }
 
@@ -81,7 +121,7 @@ function getDb() {
   if (!dbPromise) {
     dbPromise = new Promise((resolve, reject) => {
       const request = indexedDB.open(DB_NAME, 1);
-      request.onerror = () => reject("Error opening IndexedDB");
+      request.onerror = () => reject('Error opening IndexedDB');
       request.onsuccess = () => resolve(request.result);
       request.onupgradeneeded = (event) => {
         const db = event.target.result;
@@ -105,7 +145,7 @@ async function getFileFromDb(key) {
     const transaction = db.transaction([STORE_NAME], 'readonly');
     const store = transaction.objectStore(STORE_NAME);
     const request = store.get(key);
-    request.onerror = () => reject("Error reading from DB");
+    request.onerror = () => reject('Error reading from DB');
     request.onsuccess = () => resolve(request.result);
   });
 }
@@ -117,25 +157,31 @@ async function getFileFromDb(key) {
  * @returns {Promise<IDBValidKey | undefined>} IndexedDB request result.
  */
 async function saveFileToDb(key, blob) {
-    const db = await getDb();
-    return new Promise((resolve, reject) => {
-        const transaction = db.transaction([STORE_NAME], 'readwrite');
-        const store = transaction.objectStore(STORE_NAME);
-        const request = store.put(blob, key);
-        request.onerror = () => reject("Error writing to DB");
-        request.onsuccess = () => resolve(request.result);
-    });
+  const db = await getDb();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(blob, key);
+    request.onerror = () => reject('Error writing to DB');
+    request.onsuccess = () => resolve(request.result);
+  });
 }
 
 /**
  * Download a file from HuggingFace Hub with caching support.
- * @param {string} repoId Model repo ID (e.g., 'nvidia/parakeet-tdt-1.1b')
- * @param {string} filename File to download (e.g., 'encoder-model.onnx')
+ *
+ * NOTE:
+ * - `filename` and `subfolder` must be raw (not URL-encoded) path segments.
+ * - This function performs per-segment encoding internally.
+ * - Passing pre-encoded values may cause double-encoding.
+ *
+ * @param {string} repoId Model repo ID (e.g., 'nvidia/parakeet-tdt-1.1b').
+ * @param {string} filename File to download (e.g., 'encoder-model.onnx').
  * @param {Object} [options]
- * @param {string} [options.revision='main'] Git revision
- * @param {string} [options.subfolder=''] Subfolder within repo
- * @param {(progress: {loaded: number, total: number, file: string}) => void} [options.progress] Progress callback
- * @returns {Promise<string>} URL to cached file (blob URL)
+ * @param {string} [options.revision='main'] Git revision.
+ * @param {string} [options.subfolder=''] Subfolder within repo.
+ * @param {(progress: {loaded: number, total: number, file: string}) => void} [options.progress] Progress callback.
+ * @returns {Promise<string>} URL to cached file (blob URL).
  */
 export async function getModelFile(repoId, filename, options = {}) {
   const { revision = 'main', subfolder = '', progress } = options;
@@ -147,17 +193,15 @@ export async function getModelFile(repoId, filename, options = {}) {
     .split('/')
     .map((part) => encodeURIComponent(part))
     .join('/');
-  
-  // Construct HF URL
+
   const baseUrl = 'https://huggingface.co';
   const pathParts = [repoId, 'resolve', encodedRevision];
   if (encodedSubfolder) pathParts.push(encodedSubfolder);
   pathParts.push(encodedFilename);
   const url = `${baseUrl}/${pathParts.join('/')}`;
-  
-  // Check IndexedDB first
+
   const cacheKey = `hf-${repoId}-${revision}-${subfolder}-${filename}`;
-  
+
   if (typeof indexedDB !== 'undefined') {
     try {
       const cachedBlob = await getFileFromDb(cacheKey);
@@ -169,212 +213,256 @@ export async function getModelFile(repoId, filename, options = {}) {
       console.warn('[Hub] IndexedDB cache check failed:', e);
     }
   }
-  
-  // Download from HF
+
   console.log(`[Hub] Downloading ${filename} from ${repoId}...`);
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Failed to download ${filename}: ${response.status} ${response.statusText}`);
   }
-  
-  // Stream with progress
+
   const contentLength = response.headers.get('content-length');
-  const total = contentLength ? parseInt(contentLength) : 0;
+  const total = contentLength ? parseInt(contentLength, 10) : 0;
   let loaded = 0;
-  
+
   const reader = response.body.getReader();
   const chunks = [];
-  
+
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    
+
     chunks.push(value);
     loaded += value.length;
-    
+
     if (progress && total > 0) {
       progress({ loaded, total, file: filename });
     }
   }
-  
-  // Reconstruct blob
+
   const blob = new Blob(chunks, { type: response.headers.get('content-type') || 'application/octet-stream' });
-  
-  // Cache the blob in IndexedDB
+
   if (typeof indexedDB !== 'undefined') {
     try {
       await saveFileToDb(cacheKey, blob);
-       console.log(`[Hub] Cached ${filename} in IndexedDB`);
+      console.log(`[Hub] Cached ${filename} in IndexedDB`);
     } catch (e) {
       console.warn('[Hub] Failed to cache in IndexedDB:', e);
     }
   }
-  
+
   return URL.createObjectURL(blob);
 }
 
 /**
  * Download text file from HF Hub.
- * @param {string} repoId Model repo ID
- * @param {string} filename Text file to download
- * @param {Object} [options] Same as getModelFile
- * @returns {Promise<string>} File content as text
+ * @param {string} repoId Model repo ID.
+ * @param {string} filename Text file to download.
+ * @param {Object} [options] Same as getModelFile.
+ * @returns {Promise<string>} File content as text.
  */
 export async function getModelText(repoId, filename, options = {}) {
   const blobUrl = await getModelFile(repoId, filename, options);
   const response = await fetch(blobUrl);
   const text = await response.text();
-  URL.revokeObjectURL(blobUrl); // Clean up blob URL
+  URL.revokeObjectURL(blobUrl);
   return text;
 }
 
 /**
- * Convenience function to get all Parakeet model files for a given architecture.
- * @param {string} repoIdOrModelKey HF repo (e.g., 'nvidia/parakeet-tdt-1.1b') or model key (e.g., 'parakeet-tdt-0.6b-v3')
- * @param {Object} [options]
- * @param {('int8'|'fp32'|'fp16')} [options.encoderQuant='int8'] Encoder quantization
- * @param {('int8'|'fp32'|'fp16')} [options.decoderQuant='int8'] Decoder quantization
- * @param {('nemo80'|'nemo128')} [options.preprocessor] Preprocessor variant (auto-detected from model config if not specified)
- * @param {('js'|'onnx')} [options.preprocessorBackend='js'] Preprocessor backend selection.
- * @param {('webgpu'|'webgpu-hybrid'|'webgpu-strict'|'wasm')} [options.backend='webgpu'] Backend mode (`webgpu` alias is accepted for compatibility)
- * @param {(progress: {loaded: number, total: number, file: string}) => void} [options.progress] Progress callback
- * @returns {Promise<{urls: {encoderUrl: string, decoderUrl: string, tokenizerUrl: string, preprocessorUrl?: string, encoderDataUrl?: string|null, decoderDataUrl?: string|null}, filenames: {encoder: string, decoder: string}, quantisation: {encoder: ('int8'|'fp32'|'fp16'), decoder: ('int8'|'fp32'|'fp16')}, modelConfig: ModelConfig|null, preprocessorBackend: ('js'|'onnx')}>}
+ * @typedef {Object} ResolvedComponent
+ * @property {'encoder'|'decoder'} name
+ * @property {'encoderUrl'|'decoderUrl'} key
+ * @property {string} baseName
+ * @property {'int8'|'fp32'|'fp16'} quant
+ * @property {string} filename
  */
-export async function getParakeetModel(repoIdOrModelKey, options = {}) {
-  // Resolve model key to repo ID and get config
-  const modelConfig = getModelConfig(repoIdOrModelKey);
-  const repoId = modelConfig?.repoId || repoIdOrModelKey;
-  
-  // Use model config defaults if available
-  const defaultPreprocessor = modelConfig?.preprocessor || 'nemo128';
-  
-  const { encoderQuant = 'int8', decoderQuant = 'int8', preprocessor = defaultPreprocessor, preprocessorBackend = 'js', backend = 'webgpu', progress } = options;
-  
-  // Decide quantisation per component
-  let encoderQ = encoderQuant;
-  let decoderQ = decoderQuant;
 
-  if (backend.startsWith('webgpu') && encoderQ === 'int8') {
-    console.warn('[Hub] Forcing encoder to fp32 on WebGPU (int8 unsupported)');
-    encoderQ = 'fp32';
-  }
-
-  const repoFiles = await listRepoFiles(repoId, options.revision || 'main');
-  const hasRepoListing = repoFiles.length > 0;
-
-  const components = {
-    encoder: {
-      key: 'encoderUrl',
-      baseName: 'encoder-model',
-      filename: getQuantizedModelName('encoder-model', encoderQ),
-      quant: encoderQ,
-    },
-    decoder: {
-      key: 'decoderUrl',
-      baseName: 'decoder_joint-model',
-      filename: getQuantizedModelName('decoder_joint-model', decoderQ),
-      quant: decoderQ,
-    },
+/**
+ * @param {'encoder'|'decoder'} name
+ * @param {'int8'|'fp32'|'fp16'} quant
+ * @returns {ResolvedComponent}
+ */
+function createComponent(name, quant) {
+  const baseName = name === 'encoder' ? 'encoder-model' : 'decoder_joint-model';
+  const key = name === 'encoder' ? 'encoderUrl' : 'decoderUrl';
+  return {
+    name,
+    key,
+    baseName,
+    quant,
+    filename: getQuantizedModelName(baseName, quant),
   };
+}
 
-  for (const [name, component] of Object.entries(components)) {
-    if (component.quant !== 'fp16') continue;
-    if (!hasRepoListing) continue;
+/**
+ * Validate requested FP16 component exists when listing is available.
+ * Does not mutate quantization choice; throws actionable errors instead.
+ *
+ * @param {ResolvedComponent} component
+ * @param {string} repoId
+ * @param {string[]|null} repoFiles
+ */
+function validateRequestedFp16Component(component, repoId, repoFiles) {
+  if (component.quant !== 'fp16' || repoFiles === null) return;
 
-    const fp16Name = getQuantizedModelName(component.baseName, 'fp16');
-    const fp32Name = getQuantizedModelName(component.baseName, 'fp32');
+  const fp16Name = getQuantizedModelName(component.baseName, 'fp16');
+  const fp32Name = getQuantizedModelName(component.baseName, 'fp32');
 
-    if (repoFiles.includes(fp16Name)) continue;
-    if (repoFiles.includes(fp32Name)) {
-      console.warn(`[Hub] ${name} FP16 file missing in ${repoId}; falling back to FP32 (${fp32Name})`);
-      component.filename = fp32Name;
-      component.quant = 'fp32';
-      continue;
-    }
+  if (repoHasFile(repoFiles, fp16Name)) return;
 
+  if (repoHasFile(repoFiles, fp32Name)) {
     throw new Error(
-      `[Hub] Missing ${name} model in ${repoId}: requested ${fp16Name}, fallback ${fp32Name} is also unavailable`
+      `[Hub] ${component.name} FP16 file is missing in ${repoId} (found ${fp32Name} instead). ` +
+      `Requested quantization is strict; choose encoderQuant/decoderQuant='fp32' explicitly.`
     );
   }
 
-  const filesToGet = [
-    { key: components.encoder.key, name: components.encoder.filename },
-    { key: components.decoder.key, name: components.decoder.filename },
-    { key: 'tokenizerUrl', name: 'vocab.txt' },
+  throw new Error(
+    `[Hub] Missing ${component.name} model in ${repoId}: requested ${fp16Name}.`
+  );
+}
+
+/**
+ * @param {{encoder: ResolvedComponent, decoder: ResolvedComponent}} components
+ * @param {'js'|'onnx'} preprocessorBackend
+ * @param {'nemo80'|'nemo128'} preprocessor
+ * @returns {Array<{key: string, name: string, componentName?: 'encoder'|'decoder', optional?: boolean}>}
+ */
+function buildRequiredDownloads(components, preprocessorBackend, preprocessor) {
+  const files = [
+    {
+      key: components.encoder.key,
+      name: components.encoder.filename,
+      componentName: 'encoder',
+      optional: false,
+    },
+    {
+      key: components.decoder.key,
+      name: components.decoder.filename,
+      componentName: 'decoder',
+      optional: false,
+    },
+    { key: 'tokenizerUrl', name: 'vocab.txt', optional: false },
   ];
 
-  // Only download preprocessor ONNX when not using JS backend
   if (preprocessorBackend !== 'js') {
-    filesToGet.push({ key: 'preprocessorUrl', name: `${preprocessor}.onnx` });
+    files.push({ key: 'preprocessorUrl', name: `${preprocessor}.onnx`, optional: false });
     console.log(`[Hub] Preprocessor: ONNX — will download ${preprocessor}.onnx`);
   } else {
     console.log(`[Hub] Preprocessor: JS (mel.js) — skipping ${preprocessor}.onnx download`);
   }
 
-  const results = {
-      urls: {},
-      filenames: {
-          encoder: components.encoder.filename,
-          decoder: components.decoder.filename
-      },
-      quantisation: { encoder: components.encoder.quant, decoder: components.decoder.quant },
-      modelConfig: modelConfig || null,  // Include model config for downstream use
-      preprocessorBackend,  // Pass through so callers know which backend to use
-  };
+  return files;
+}
 
-  for (const file of filesToGet) {
-    const { key, name } = file;
-    try {
-      results.urls[key] = await getModelFile(repoId, name, { ...options, progress });
-    } catch (e) {
-      if (key !== 'encoderUrl' && key !== 'decoderUrl') {
-        throw e;
-      }
-
-      const componentName = key === 'encoderUrl' ? 'encoder' : 'decoder';
-      const component = components[componentName];
-      const fallbackName = getQuantizedModelName(component.baseName, 'fp32');
-
-      // If FP16 was optimistically selected (repo listing unavailable), fallback at download time.
-      if (component.quant === 'fp16' && fallbackName !== name) {
-        console.warn(
-          `[Hub] ${componentName} FP16 download failed (${name}); retrying with FP32 (${fallbackName})`,
-          e
-        );
-        try {
-          results.urls[key] = await getModelFile(repoId, fallbackName, { ...options, progress });
-          component.filename = fallbackName;
-          component.quant = 'fp32';
-          results.filenames[componentName] = fallbackName;
-          results.quantisation[componentName] = 'fp32';
-          continue;
-        } catch (fallbackError) {
-          throw new Error(
-            `[Hub] Missing ${componentName} model in ${repoId}: requested ${name}, fallback ${fallbackName} failed (${fallbackError.message || fallbackError})`
-          );
-        }
-      } else {
-        throw e;
-      }
-    }
-  }
-
-  // Conditionally include external data files.
-  // If repo listing is unavailable, try optimistic fetch for compatibility.
-  const externalDataCandidates = [
-    { key: 'encoderDataUrl', name: `${components.encoder.filename}.data` },
-    { key: 'decoderDataUrl', name: `${components.decoder.filename}.data` },
+/**
+ * @param {{encoder: ResolvedComponent, decoder: ResolvedComponent}} components
+ * @param {string[]|null} repoFiles
+ * @returns {Array<{key: 'encoderDataUrl'|'decoderDataUrl', name: string, optional: true}>}
+ */
+function buildOptionalExternalDataDownloads(components, repoFiles) {
+  const candidates = [
+    { key: 'encoderDataUrl', name: `${components.encoder.filename}.data`, optional: true },
+    { key: 'decoderDataUrl', name: `${components.decoder.filename}.data`, optional: true },
   ];
 
-  for (const { key, name } of externalDataCandidates) {
-    if (hasRepoListing && !repoFiles.includes(name)) continue;
+  if (repoFiles === null) return candidates;
+  return candidates.filter((entry) => repoHasFile(repoFiles, entry.name));
+}
+
+/**
+ * Convenience function to get all Parakeet model files for a given architecture.
+ *
+ * Quantization behavior:
+ * - Requested quantization is strict (no automatic FP16 -> FP32 fallback in core API).
+ * - If requested files are missing, throws actionable errors.
+ *
+ * @param {string} repoIdOrModelKey HF repo (e.g., 'nvidia/parakeet-tdt-1.1b') or model key (e.g., 'parakeet-tdt-0.6b-v3').
+ * @param {Object} [options]
+ * @param {('int8'|'fp32'|'fp16')} [options.encoderQuant='int8'] Encoder quantization.
+ * @param {('int8'|'fp32'|'fp16')} [options.decoderQuant='int8'] Decoder quantization.
+ * @param {('nemo80'|'nemo128')} [options.preprocessor] Preprocessor variant (auto-detected from model config if not specified).
+ * @param {('js'|'onnx')} [options.preprocessorBackend='js'] Preprocessor backend selection.
+ * @param {('webgpu'|'webgpu-hybrid'|'webgpu-strict'|'wasm')} [options.backend='webgpu'] Backend mode (`webgpu` alias is accepted for compatibility).
+ * @param {(progress: {loaded: number, total: number, file: string}) => void} [options.progress] Progress callback.
+ * @returns {Promise<{urls: {encoderUrl: string, decoderUrl: string, tokenizerUrl: string, preprocessorUrl?: string, encoderDataUrl?: string|null, decoderDataUrl?: string|null}, filenames: {encoder: string, decoder: string}, quantisation: {encoder: ('int8'|'fp32'|'fp16'), decoder: ('int8'|'fp32'|'fp16')}, modelConfig: ModelConfig|null, preprocessorBackend: ('js'|'onnx')}>}
+ */
+export async function getParakeetModel(repoIdOrModelKey, options = {}) {
+  const modelConfig = getModelConfig(repoIdOrModelKey);
+  const repoId = modelConfig?.repoId || repoIdOrModelKey;
+  const defaultPreprocessor = modelConfig?.preprocessor || 'nemo128';
+
+  const {
+    encoderQuant = 'int8',
+    decoderQuant = 'int8',
+    preprocessor = defaultPreprocessor,
+    preprocessorBackend = 'js',
+    backend = 'webgpu',
+    progress,
+  } = options;
+
+  let encoderQ = encoderQuant;
+  if (backend.startsWith('webgpu') && encoderQ === 'int8') {
+    console.warn('[Hub] Forcing encoder to fp32 on WebGPU (int8 unsupported)');
+    encoderQ = 'fp32';
+  }
+
+  const components = {
+    encoder: createComponent('encoder', encoderQ),
+    decoder: createComponent('decoder', decoderQuant),
+  };
+
+  const repoFiles = await listRepoFiles(repoId, options.revision || 'main');
+
+  validateRequestedFp16Component(components.encoder, repoId, repoFiles);
+  validateRequestedFp16Component(components.decoder, repoId, repoFiles);
+
+  const requiredFiles = buildRequiredDownloads(components, preprocessorBackend, preprocessor);
+
+  const results = {
+    urls: {},
+    filenames: {
+      encoder: components.encoder.filename,
+      decoder: components.decoder.filename,
+    },
+    quantisation: {
+      encoder: components.encoder.quant,
+      decoder: components.decoder.quant,
+    },
+    modelConfig: modelConfig || null,
+    preprocessorBackend,
+  };
+
+  for (const file of requiredFiles) {
     try {
-      results.urls[key] = await getModelFile(repoId, name, { ...options, progress });
-    } catch (e) {
-      console.warn(`[Hub] Optional external data file not found: ${name}. This is expected if the model is small.`);
-      results.urls[key] = null;
+      results.urls[file.key] = await getModelFile(repoId, file.name, { ...options, progress });
+    } catch (err) {
+      if (!file.componentName) {
+        throw err;
+      }
+
+      const component = components[file.componentName];
+      if (component.quant === 'fp16') {
+        throw new Error(
+          `[Hub] ${component.name} FP16 download failed (${file.name}). ` +
+          `Requested quantization is strict; choose encoderQuant/decoderQuant='fp32' explicitly. ` +
+          `Original error: ${err.message || err}`
+        );
+      }
+
+      throw err;
     }
   }
-  
+
+  const optionalFiles = buildOptionalExternalDataDownloads(components, repoFiles);
+  for (const file of optionalFiles) {
+    try {
+      results.urls[file.key] = await getModelFile(repoId, file.name, { ...options, progress });
+    } catch {
+      console.warn(`[Hub] Optional external data file not found: ${file.name}. This is expected if the model is small.`);
+      results.urls[file.key] = null;
+    }
+  }
+
   return results;
 }

--- a/src/hub.js
+++ b/src/hub.js
@@ -32,7 +32,7 @@ async function listRepoFiles(repoId, revision = 'main') {
   const cacheKey = `${repoId}@${revision}`;
   if (repoFileCache.has(cacheKey)) return repoFileCache.get(cacheKey);
 
-  const url = `https://huggingface.co/api/models/${repoId}?revision=${revision}`;
+  const url = `https://huggingface.co/api/models/${repoId}?revision=${encodeURIComponent(revision)}`;
   try {
     const resp = await fetch(url);
     if (!resp.ok) throw new Error(`Failed to list repo files: ${resp.status}`);
@@ -114,12 +114,20 @@ async function saveFileToDb(key, blob) {
  */
 export async function getModelFile(repoId, filename, options = {}) {
   const { revision = 'main', subfolder = '', progress } = options;
+  const encodedRevision = encodeURIComponent(revision);
+  const encodedSubfolder = subfolder
+    ? subfolder.split('/').map((part) => encodeURIComponent(part)).join('/')
+    : '';
+  const encodedFilename = filename
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
   
   // Construct HF URL
   const baseUrl = 'https://huggingface.co';
-  const pathParts = [repoId, 'resolve', revision];
-  if (subfolder) pathParts.push(subfolder);
-  pathParts.push(filename);
+  const pathParts = [repoId, 'resolve', encodedRevision];
+  if (encodedSubfolder) pathParts.push(encodedSubfolder);
+  pathParts.push(encodedFilename);
   const url = `${baseUrl}/${pathParts.join('/')}`;
   
   // Check IndexedDB first

--- a/src/hub.js
+++ b/src/hub.js
@@ -347,11 +347,7 @@ function validateRequestedFp16Component(component, repoId, repoFiles) {
  * @param {'nemo80'|'nemo128'} preprocessor
  * @returns {Array<{key: string, name: string, componentName?: 'encoder'|'decoder', optional?: boolean}>}
  */
- * @param {{encoder: ResolvedComponent, decoder: ResolvedComponent}} components
- * @param {'js'|'onnx'} preprocessorBackend
- * @param {'nemo80'|'nemo128'} preprocessor
- * @param {boolean} [verbose=false] Whether to log preprocessor selection.
- * @returns {Array<{key: string, name: string, componentName?: 'encoder'|'decoder', optional?: boolean}>}
+function buildRequiredDownloads(components, preprocessorBackend, preprocessor, verbose = false) {
   const files = [
     {
       key: components.encoder.key,

--- a/src/hub.js
+++ b/src/hub.js
@@ -26,7 +26,13 @@ const QUANT_SUFFIX = {
  * @returns {string} Filename with quant suffix (e.g. 'encoder-model.fp16.onnx').
  */
 function getQuantizedModelName(baseName, quant) {
-  return `${baseName}${QUANT_SUFFIX[quant] || QUANT_SUFFIX.fp32}`;
+  const suffix = QUANT_SUFFIX[quant];
+  if (!suffix) {
+    throw new Error(
+      `[Hub] Unknown quantization '${quant}'; expected one of: ${Object.keys(QUANT_SUFFIX).join(', ')}`
+    );
+  }
+  return `${baseName}${suffix}`;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,30 @@ export async function fromUrls(cfg) {
   return ParakeetModel.fromUrls(cfg);
 }
 
+function usesRequestedFp16(options) {
+  return options?.encoderQuant === 'fp16' || options?.decoderQuant === 'fp16';
+}
+
+function buildFp16CompileHint(options) {
+  const backend = String(options?.backend || '');
+  const isWebgpu = backend.startsWith('webgpu');
+  const decoderFp16 = options?.decoderQuant === 'fp16';
+
+  if (isWebgpu && decoderFp16) {
+    return "Decoder runs on WASM in WebGPU modes; try decoderQuant: 'int8' or 'fp32'.";
+  }
+
+  return "Try encoderQuant/decoderQuant: 'fp32' (or 'int8' where supported).";
+}
+
 /**
  * Convenience factory to load from HuggingFace Hub.
+ *
+ * Behavior notes:
+ * - Requested quantization is strict; this function does not auto-switch `fp16` to `fp32`.
+ * - If model compile/session creation fails, the original error is propagated.
+ * - For FP16 requests, an additional actionable hint is included in the thrown error.
+ *
  * @param {string} repoIdOrModelKey - Hugging Face repo ID or known model key.
  * @param {Object} [options={}] - Download/runtime options forwarded to hub/model loaders (e.g. encoderQuant, decoderQuant: 'int8'|'fp32'|'fp16', backend, progress).
  * @returns {Promise<ParakeetModel>} Loaded Parakeet model instance.
@@ -32,14 +54,25 @@ export async function fromUrls(cfg) {
  * const model = await fromHub('parakeet-tdt-0.6b-v3', { backend: 'webgpu-hybrid' });
  */
 export async function fromHub(repoIdOrModelKey, options = {}) {
-  // Resolve model key to repo ID if needed
   const repoId = MODELS[repoIdOrModelKey]?.repoId || repoIdOrModelKey;
-
   const result = await getParakeetModel(repoId, options);
-  return ParakeetModel.fromUrls({
+  const fromUrlsConfig = {
     ...result.urls,
     filenames: result.filenames,
     preprocessorBackend: result.preprocessorBackend,
     ...options,
-  });
+  };
+
+  try {
+    return await ParakeetModel.fromUrls(fromUrlsConfig);
+  } catch (error) {
+    if (!usesRequestedFp16(options)) {
+      throw error;
+    }
+
+    const hint = buildFp16CompileHint(options);
+    const baseMessage = error?.message || String(error);
+    console.warn(`[fromHub] FP16 compile/session load failed. ${hint}`, error);
+    throw new Error(`[fromHub] FP16 compile/session load failed. ${hint} Original error: ${baseMessage}`);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export async function fromUrls(cfg) {
 /**
  * Convenience factory to load from HuggingFace Hub.
  * @param {string} repoIdOrModelKey - Hugging Face repo ID or known model key.
- * @param {Object} [options={}] - Download/runtime options forwarded to hub/model loaders.
+ * @param {Object} [options={}] - Download/runtime options forwarded to hub/model loaders (e.g. encoderQuant, decoderQuant: 'int8'|'fp32'|'fp16', backend, progress).
  * @returns {Promise<ParakeetModel>} Loaded Parakeet model instance.
  * @example
  * import { fromHub } from 'parakeet.js';

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,9 @@ export async function fromHub(repoIdOrModelKey, options = {}) {
     const hint = buildFp16CompileHint(options);
     const baseMessage = error?.message || String(error);
     console.warn(`[fromHub] FP16 compile/session load failed. ${hint}`, error);
-    throw new Error(`[fromHub] FP16 compile/session load failed. ${hint} Original error: ${baseMessage}`);
+    throw new Error(
+      `[fromHub] FP16 compile/session load failed. ${hint} Original error: ${baseMessage}`,
+      { cause: error }
+    );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export async function fromUrls(cfg) {
  * @returns {Promise<ParakeetModel>} Loaded Parakeet model instance.
  * @example
  * import { fromHub } from 'parakeet.js';
- * const model = await fromHub('istupakov/parakeet-tdt-0.6b-v3-onnx', { decoderQuant: 'int8' });
+ * const model = await fromHub('ysdede/parakeet-tdt-0.6b-v3-onnx', { decoderQuant: 'int8' });
  *
  * // Or use a model key for known models:
  * const model = await fromHub('parakeet-tdt-0.6b-v3', { backend: 'webgpu-hybrid' });

--- a/src/models.js
+++ b/src/models.js
@@ -66,6 +66,18 @@ export const MODELS = {
     predHidden: 640,
     predLayers: 2,
   },
+  'parakeet-tdt-0.6b-v3-fp16': {
+    repoId: 'grikdotnet/parakeet-tdt-0.6b-fp16',
+    displayName: 'Parakeet TDT 0.6B v3 (Multilingual, FP16)',
+    languages: ['en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'pl', 'ru', 'uk', 'ja', 'ko', 'zh'],
+    defaultLanguage: 'en',
+    vocabSize: 4097,
+    featuresSize: 128,
+    preprocessor: 'nemo128',
+    subsampling: 8,
+    predHidden: 640,
+    predLayers: 2,
+  },
 };
 
 /**

--- a/src/models.js
+++ b/src/models.js
@@ -66,18 +66,6 @@ export const MODELS = {
     predHidden: 640,
     predLayers: 2,
   },
-  'parakeet-tdt-0.6b-v3-fp16': {
-    repoId: 'ysdede/parakeet-tdt-0.6b-v3-onnx',
-    displayName: 'Parakeet TDT 0.6B v3 (Multilingual, FP16)',
-    languages: ['en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'pl', 'ru', 'uk', 'ja', 'ko', 'zh'],
-    defaultLanguage: 'en',
-    vocabSize: 4097,
-    featuresSize: 128,
-    preprocessor: 'nemo128',
-    subsampling: 8,
-    predHidden: 640,
-    predLayers: 2,
-  },
 };
 
 /**

--- a/src/models.js
+++ b/src/models.js
@@ -55,7 +55,7 @@ export const MODELS = {
     predLayers: 2,
   },
   'parakeet-tdt-0.6b-v3': {
-    repoId: 'istupakov/parakeet-tdt-0.6b-v3-onnx',
+    repoId: 'ysdede/parakeet-tdt-0.6b-v3-onnx',
     displayName: 'Parakeet TDT 0.6B v3 (Multilingual)',
     languages: ['en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'pl', 'ru', 'uk', 'ja', 'ko', 'zh'],
     defaultLanguage: 'en',
@@ -67,7 +67,7 @@ export const MODELS = {
     predLayers: 2,
   },
   'parakeet-tdt-0.6b-v3-fp16': {
-    repoId: 'grikdotnet/parakeet-tdt-0.6b-fp16',
+    repoId: 'ysdede/parakeet-tdt-0.6b-v3-onnx',
     displayName: 'Parakeet TDT 0.6B v3 (Multilingual, FP16)',
     languages: ['en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'pl', 'ru', 'uk', 'ja', 'ko', 'zh'],
     defaultLanguage: 'en',

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -146,4 +146,29 @@ describe('getParakeetModel quantization resolution', () => {
     expect(res.filenames.decoder).toBe('decoder_joint-model.int8.onnx');
     expect(res.quantisation.decoder).toBe('int8');
   });
+
+  it('encodes slash branch names in API and resolve URLs', async () => {
+    const repoId = 'test/repo-branch-slash';
+    const revision = 'feat/fp16-canonical-v2';
+    const { calls } = installFetchMock({
+      repoId,
+      siblings: [
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      revision,
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.filenames.encoder).toBe('encoder-model.fp16.onnx');
+    expect(calls.some((x) => x.includes(`/api/models/${repoId}?revision=feat%2Ffp16-canonical-v2`))).toBe(true);
+    expect(calls.some((x) => x.includes('/resolve/feat%2Ffp16-canonical-v2/encoder-model.fp16.onnx'))).toBe(true);
+  });
 });

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getParakeetModel } from '../src/hub.js';
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function binaryResponse(status = 200) {
+  return new Response(new Uint8Array([1, 2, 3]), {
+    status,
+    headers: {
+      'content-type': 'application/octet-stream',
+      'content-length': '3',
+    },
+  });
+}
+
+function installFetchMock({ repoId, siblings, missing = [] }) {
+  const missingSet = new Set(missing);
+  const calls = [];
+
+  const mock = vi.fn(async (url) => {
+    const href = String(url);
+    calls.push(href);
+
+    if (href.includes(`/api/models/${repoId}`)) {
+      return jsonResponse({
+        siblings: siblings.map((name) => ({ rfilename: name })),
+      });
+    }
+
+    const match = href.match(/\/resolve\/[^/]+\/(.+)$/);
+    if (!match) return binaryResponse(404);
+    const filename = match[1];
+    if (missingSet.has(filename)) {
+      return new Response('missing', { status: 404, statusText: 'Not Found' });
+    }
+    return binaryResponse(200);
+  });
+
+  vi.stubGlobal('fetch', mock);
+  vi.stubGlobal('indexedDB', undefined);
+  return { calls, mock };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('getParakeetModel quantization resolution', () => {
+  it('uses FP16 files when available', async () => {
+    const repoId = 'test/repo-fp16-present';
+    installFetchMock({
+      repoId,
+      siblings: [
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.filenames.encoder).toBe('encoder-model.fp16.onnx');
+    expect(res.filenames.decoder).toBe('decoder_joint-model.fp16.onnx');
+    expect(res.quantisation.encoder).toBe('fp16');
+    expect(res.quantisation.decoder).toBe('fp16');
+  });
+
+  it('falls back FP16 to FP32 when FP16 files are missing', async () => {
+    const repoId = 'test/repo-fp16-fallback';
+    const { calls } = installFetchMock({
+      repoId,
+      siblings: [
+        'encoder-model.onnx',
+        'decoder_joint-model.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.filenames.encoder).toBe('encoder-model.onnx');
+    expect(res.filenames.decoder).toBe('decoder_joint-model.onnx');
+    expect(res.quantisation.encoder).toBe('fp32');
+    expect(res.quantisation.decoder).toBe('fp32');
+    expect(calls.some((x) => x.includes('encoder-model.fp16.onnx'))).toBe(false);
+    expect(calls.some((x) => x.includes('decoder_joint-model.fp16.onnx'))).toBe(false);
+  });
+
+  it('throws actionable error when both FP16 and FP32 are unavailable', async () => {
+    const repoId = 'test/repo-fp16-missing';
+    installFetchMock({
+      repoId,
+      siblings: [
+        'encoder-model.int8.onnx',
+        'decoder_joint-model.int8.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    await expect(
+      getParakeetModel(repoId, {
+        backend: 'webgpu-hybrid',
+        encoderQuant: 'fp16',
+        decoderQuant: 'fp16',
+        preprocessorBackend: 'js',
+      })
+    ).rejects.toThrow(/requested encoder-model\.fp16\.onnx/i);
+  });
+
+  it('keeps webgpu int8 encoder override behavior', async () => {
+    const repoId = 'test/repo-webgpu-int8';
+    installFetchMock({
+      repoId,
+      siblings: [
+        'encoder-model.onnx',
+        'decoder_joint-model.int8.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'int8',
+      decoderQuant: 'int8',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.filenames.encoder).toBe('encoder-model.onnx');
+    expect(res.quantisation.encoder).toBe('fp32');
+    expect(res.filenames.decoder).toBe('decoder_joint-model.int8.onnx');
+    expect(res.quantisation.decoder).toBe('int8');
+  });
+});

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -276,6 +276,30 @@ describe('getParakeetModel quantization resolution (strict mode)', () => {
     expect(state.treeCalls).toBeGreaterThanOrEqual(2);
   });
 
+  it('skips optional .data downloads when listing is unavailable', async () => {
+    const repoId = 'test/repo-no-listing-no-data-probe';
+    const { calls } = installFetchMock({
+      repoId,
+      treeShouldFail: true,
+      metadataShouldFail: true,
+      siblings: [
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.quantisation.encoder).toBe('fp16');
+    expect(calls.some((x) => x.includes('.onnx.data'))).toBe(false);
+  });
+
   it('encodes slash branch names in API and resolve URLs', async () => {
     const repoId = 'test/repo-branch-slash';
     const revision = 'feat/fp16-canonical-v2';

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -18,15 +18,50 @@ function binaryResponse(status = 200) {
   });
 }
 
-function installFetchMock({ repoId, siblings, missing = [] }) {
+function installFetchMock({
+  repoId,
+  siblings = [],
+  missing = [],
+  treeFiles,
+  treeShouldFail = false,
+  metadataShouldFail = false,
+}) {
   const missingSet = new Set(missing);
   const calls = [];
+  const state = {
+    treeCalls: 0,
+    metadataCalls: 0,
+  };
 
   const mock = vi.fn(async (url) => {
     const href = String(url);
     calls.push(href);
 
+    if (href.includes(`/api/models/${repoId}/tree/`)) {
+      state.treeCalls += 1;
+      const failTree = treeShouldFail === true || (typeof treeShouldFail === 'number' && state.treeCalls <= treeShouldFail);
+      if (failTree) {
+        return jsonResponse({ error: 'tree failed' }, 500);
+      }
+
+      if (Array.isArray(treeFiles)) {
+        return jsonResponse(treeFiles);
+      }
+
+      return jsonResponse(
+        siblings.map((name) => ({ type: 'file', path: name }))
+      );
+    }
+
     if (href.includes(`/api/models/${repoId}`)) {
+      state.metadataCalls += 1;
+      const failMetadata =
+        metadataShouldFail === true ||
+        (typeof metadataShouldFail === 'number' && state.metadataCalls <= metadataShouldFail);
+      if (failMetadata) {
+        return jsonResponse({ error: 'metadata failed' }, 500);
+      }
+
       return jsonResponse({
         siblings: siblings.map((name) => ({ rfilename: name })),
       });
@@ -34,16 +69,18 @@ function installFetchMock({ repoId, siblings, missing = [] }) {
 
     const match = href.match(/\/resolve\/[^/]+\/(.+)$/);
     if (!match) return binaryResponse(404);
-    const filename = match[1];
+
+    const filename = decodeURIComponent(match[1]);
     if (missingSet.has(filename)) {
       return new Response('missing', { status: 404, statusText: 'Not Found' });
     }
+
     return binaryResponse(200);
   });
 
   vi.stubGlobal('fetch', mock);
   vi.stubGlobal('indexedDB', undefined);
-  return { calls, mock };
+  return { calls, mock, state };
 }
 
 afterEach(() => {
@@ -51,7 +88,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('getParakeetModel quantization resolution', () => {
+describe('getParakeetModel quantization resolution (strict mode)', () => {
   it('uses FP16 files when available', async () => {
     const repoId = 'test/repo-fp16-present';
     installFetchMock({
@@ -76,13 +113,37 @@ describe('getParakeetModel quantization resolution', () => {
     expect(res.quantisation.decoder).toBe('fp16');
   });
 
-  it('falls back FP16 to FP32 when FP16 files are missing', async () => {
-    const repoId = 'test/repo-fp16-fallback';
-    const { calls } = installFetchMock({
+  it('uses tree API array shape for quantization resolution', async () => {
+    const repoId = 'test/repo-tree-shape';
+    installFetchMock({
       repoId,
+      siblings: [],
+      treeFiles: [
+        { type: 'file', path: 'nested/encoder-model.fp16.onnx' },
+        { type: 'file', path: 'nested/decoder_joint-model.fp16.onnx' },
+        { type: 'file', path: 'vocab.txt' },
+      ],
+    });
+
+    const res = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(res.quantisation.encoder).toBe('fp16');
+    expect(res.quantisation.decoder).toBe('fp16');
+  });
+
+  it('falls back to metadata listing when tree API fails', async () => {
+    const repoId = 'test/repo-tree-fails';
+    const { state } = installFetchMock({
+      repoId,
+      treeShouldFail: true,
       siblings: [
-        'encoder-model.onnx',
-        'decoder_joint-model.onnx',
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
         'vocab.txt',
       ],
     });
@@ -94,21 +155,19 @@ describe('getParakeetModel quantization resolution', () => {
       preprocessorBackend: 'js',
     });
 
-    expect(res.filenames.encoder).toBe('encoder-model.onnx');
-    expect(res.filenames.decoder).toBe('decoder_joint-model.onnx');
-    expect(res.quantisation.encoder).toBe('fp32');
-    expect(res.quantisation.decoder).toBe('fp32');
-    expect(calls.some((x) => x.includes('encoder-model.fp16.onnx'))).toBe(false);
-    expect(calls.some((x) => x.includes('decoder_joint-model.fp16.onnx'))).toBe(false);
+    expect(state.treeCalls).toBeGreaterThan(0);
+    expect(state.metadataCalls).toBeGreaterThan(0);
+    expect(res.quantisation.encoder).toBe('fp16');
+    expect(res.quantisation.decoder).toBe('fp16');
   });
 
-  it('throws actionable error when both FP16 and FP32 are unavailable', async () => {
-    const repoId = 'test/repo-fp16-missing';
-    installFetchMock({
+  it('throws explicit error when FP16 is missing but FP32 exists', async () => {
+    const repoId = 'test/repo-fp16-missing-but-fp32-present';
+    const { calls } = installFetchMock({
       repoId,
       siblings: [
-        'encoder-model.int8.onnx',
-        'decoder_joint-model.int8.onnx',
+        'encoder-model.onnx',
+        'decoder_joint-model.onnx',
         'vocab.txt',
       ],
     });
@@ -120,7 +179,39 @@ describe('getParakeetModel quantization resolution', () => {
         decoderQuant: 'fp16',
         preprocessorBackend: 'js',
       })
-    ).rejects.toThrow(/requested encoder-model\.fp16\.onnx/i);
+    ).rejects.toThrow(/strict|explicitly/i);
+
+    // Error is preflight, before resolve downloads.
+    expect(calls.some((x) => x.includes('/resolve/'))).toBe(false);
+  });
+
+  it('throws explicit error when FP16 download fails and listing is unavailable', async () => {
+    const repoId = 'test/repo-fp16-download-fail-strict';
+    const { calls } = installFetchMock({
+      repoId,
+      treeShouldFail: true,
+      metadataShouldFail: true,
+      missing: [
+        'encoder-model.fp16.onnx',
+      ],
+      siblings: [
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    await expect(
+      getParakeetModel(repoId, {
+        backend: 'webgpu-hybrid',
+        encoderQuant: 'fp16',
+        decoderQuant: 'fp16',
+        preprocessorBackend: 'js',
+      })
+    ).rejects.toThrow(/strict|explicitly/i);
+
+    expect(calls.some((x) => x.includes('encoder-model.fp16.onnx'))).toBe(true);
+    expect(calls.some((x) => x.includes('encoder-model.onnx'))).toBe(false);
   });
 
   it('keeps webgpu int8 encoder override behavior', async () => {
@@ -145,6 +236,44 @@ describe('getParakeetModel quantization resolution', () => {
     expect(res.quantisation.encoder).toBe('fp32');
     expect(res.filenames.decoder).toBe('decoder_joint-model.int8.onnx');
     expect(res.quantisation.decoder).toBe('int8');
+  });
+
+  it('does not cache failed file-listing lookups', async () => {
+    const repoId = 'test/repo-no-cache-poison';
+    const { state } = installFetchMock({
+      repoId,
+      // Fail first listing attempt only, then recover.
+      treeShouldFail: 1,
+      metadataShouldFail: 1,
+      treeFiles: [
+        { type: 'file', path: 'encoder-model.fp16.onnx' },
+        { type: 'file', path: 'decoder_joint-model.fp16.onnx' },
+        { type: 'file', path: 'vocab.txt' },
+      ],
+      siblings: [
+        'encoder-model.fp16.onnx',
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    const first = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    const second = await getParakeetModel(repoId, {
+      backend: 'webgpu-hybrid',
+      encoderQuant: 'fp16',
+      decoderQuant: 'fp16',
+      preprocessorBackend: 'js',
+    });
+
+    expect(first.quantisation.encoder).toBe('fp16');
+    expect(second.quantisation.encoder).toBe('fp16');
+    expect(state.treeCalls).toBeGreaterThanOrEqual(2);
   });
 
   it('encodes slash branch names in API and resolve URLs', async () => {

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -168,7 +168,7 @@ describe('getParakeetModel quantization resolution', () => {
     });
 
     expect(res.filenames.encoder).toBe('encoder-model.fp16.onnx');
-    expect(calls.some((x) => x.includes(`/api/models/${repoId}?revision=feat%2Ffp16-canonical-v2`))).toBe(true);
+    expect(calls.some((x) => x.includes(`/api/models/${repoId}/tree/feat%2Ffp16-canonical-v2`))).toBe(true);
     expect(calls.some((x) => x.includes('/resolve/feat%2Ffp16-canonical-v2/encoder-model.fp16.onnx'))).toBe(true);
   });
 });

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fromUrls, fromHub } from '../src/index.js';
 import { ParakeetModel } from '../src/parakeet.js';
 import { getParakeetModel } from '../src/hub.js';
@@ -21,6 +21,10 @@ vi.mock('../src/hub.js', async (importOriginal) => {
   };
 });
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('index.js', () => {
   it('fromUrls should call ParakeetModel.fromUrls', async () => {
     const cfg = { some: 'config' };
@@ -28,13 +32,14 @@ describe('index.js', () => {
     expect(ParakeetModel.fromUrls).toHaveBeenCalledWith(cfg);
   });
 
-  it('fromHub should call getParakeetModel and ParakeetModel.fromUrls', async () => {
+  it('fromHub should call getParakeetModel and ParakeetModel.fromUrls once', async () => {
     const repoId = 'some-repo';
     const options = { opt: 'val' };
     const mockModelData = {
       urls: { u: 1 },
       filenames: { f: 1 },
-      preprocessorBackend: 'js'
+      preprocessorBackend: 'js',
+      quantisation: { encoder: 'fp16', decoder: 'fp16' },
     };
 
     getParakeetModel.mockResolvedValue(mockModelData);
@@ -42,11 +47,36 @@ describe('index.js', () => {
     await fromHub(repoId, options);
 
     expect(getParakeetModel).toHaveBeenCalledWith(repoId, options);
+    expect(getParakeetModel).toHaveBeenCalledTimes(1);
+    expect(ParakeetModel.fromUrls).toHaveBeenCalledTimes(1);
     expect(ParakeetModel.fromUrls).toHaveBeenCalledWith({
       ...mockModelData.urls,
       filenames: mockModelData.filenames,
       preprocessorBackend: mockModelData.preprocessorBackend,
       ...options,
     });
+  });
+
+  it('fromHub should throw actionable FP16 compile hint without internal retry', async () => {
+    const repoId = 'some-repo';
+    const options = { backend: 'webgpu-hybrid', encoderQuant: 'fp16', decoderQuant: 'fp16' };
+
+    const modelData = {
+      urls: { encoderUrl: 'enc-fp16', decoderUrl: 'dec-fp16', tokenizerUrl: 'tok' },
+      filenames: { encoder: 'encoder-model.fp16.onnx', decoder: 'decoder_joint-model.fp16.onnx' },
+      preprocessorBackend: 'js',
+      quantisation: { encoder: 'fp16', decoder: 'fp16' },
+    };
+
+    getParakeetModel.mockResolvedValue(modelData);
+    ParakeetModel.fromUrls.mockRejectedValue(new Error('compile failed'));
+
+    const error = await fromHub(repoId, options).catch((err) => err);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatch(/FP16 compile\/session load failed/i);
+    expect(error.message).toMatch(/decoderQuant: 'int8' or 'fp32'/i);
+    expect(error.message).toMatch(/compile failed/i);
+    expect(getParakeetModel).toHaveBeenCalledTimes(1);
+    expect(ParakeetModel.fromUrls).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/model-loader.test.mjs
+++ b/tests/model-loader.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadModelWithFallback } from '../examples/shared/modelLoader.js';
+
+describe('loadModelWithFallback', () => {
+  it('preserves first compile error context when fp32 retry download fails', async () => {
+    const getParakeetModelFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        urls: {},
+        filenames: {
+          encoder: 'encoder-model.fp16.onnx',
+          decoder: 'decoder_joint-model.int8.onnx',
+        },
+        quantisation: { encoder: 'fp16', decoder: 'int8' },
+        preprocessorBackend: 'js',
+      })
+      .mockRejectedValueOnce(new Error('fp32 artifact download failed'));
+
+    const fromUrlsFn = vi.fn().mockRejectedValueOnce(new Error('fp16 session compile failed'));
+
+    await expect(
+      loadModelWithFallback({
+        repoIdOrModelKey: 'parakeet-tdt-0.6b-v3',
+        options: { backend: 'webgpu-hybrid', encoderQuant: 'fp16', decoderQuant: 'int8' },
+        getParakeetModelFn,
+        fromUrlsFn,
+      })
+    ).rejects.toThrow(
+      /Initial compile failed \(fp16 session compile failed\).*FP32 retry download failed \(fp32 artifact download failed\)/i
+    );
+
+    expect(getParakeetModelFn).toHaveBeenCalledTimes(2);
+    expect(fromUrlsFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/models.test.mjs
+++ b/tests/models.test.mjs
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getModelKeyFromRepoId } from '../src/models.js';
+
+describe('models.getModelKeyFromRepoId', () => {
+  it('returns model key for unique repoId', () => {
+    expect(getModelKeyFromRepoId('ysdede/parakeet-tdt-0.6b-v2-onnx')).toBe('parakeet-tdt-0.6b-v2');
+  });
+
+  it('returns model key for v3 repoId', () => {
+    expect(getModelKeyFromRepoId('ysdede/parakeet-tdt-0.6b-v3-onnx')).toBe('parakeet-tdt-0.6b-v3');
+  });
+
+  it('returns null for unknown repoId', () => {
+    expect(getModelKeyFromRepoId('unknown/repo')).toBeNull();
+  });
+});

--- a/types/hub.d.ts
+++ b/types/hub.d.ts
@@ -15,8 +15,8 @@ export interface GetModelFileOptions {
 
 export interface GetParakeetModelOptions {
   revision?: string;
-  encoderQuant?: 'int8' | 'fp32';
-  decoderQuant?: 'int8' | 'fp32';
+  encoderQuant?: 'int8' | 'fp32' | 'fp16';
+  decoderQuant?: 'int8' | 'fp32' | 'fp16';
   preprocessor?: 'nemo80' | 'nemo128';
   preprocessorBackend?: PreprocessorBackend;
   backend?: BackendMode;
@@ -37,8 +37,8 @@ export interface GetParakeetModelResult {
     decoder: string;
   };
   quantisation: {
-    encoder: 'int8' | 'fp32';
-    decoder: 'int8' | 'fp32';
+    encoder: 'int8' | 'fp32' | 'fp16';
+    decoder: 'int8' | 'fp32' | 'fp16';
   };
   modelConfig: ModelConfig | null;
   preprocessorBackend: PreprocessorBackend;


### PR DESCRIPTION
## Summary

This PR keeps the **full original FP16 support scope** and adds the latest hardening/clarifications requested during review.

It includes:
- initial FP16 quantization support work (hub + demos + docs + tests), and
- follow-up fixes to make behavior explicit, robust, and reviewer-aligned.

## Final Behavior

- Core API (`fromHub` / `getParakeetModel`) is **strict** for requested quantization.
- Core API does **not** auto-switch `fp16` to `fp32`.
- Core API returns actionable errors/warnings for missing/unsupported FP16 paths.
- Demo layer provides user-friendly retry UX and persisted settings.

## Scope Included

### 1) Full FP16 support (original PR scope)
- FP16 quantization support in loading APIs.
- Branch/revision-aware model file resolution.
- Demo branch selection + quantization option filtering.
- FP16 docs/tests coverage and 1.3.0 version bump context.

### 2) Latest fixes/hardening
- Hardened HF listing flow (tree -> metadata fallback) and failure-cache behavior.
- Strict FP16 artifact validation/error semantics in core.
- `fromHub` compile error messaging improved with actionable hint.
- Removed redundant `parakeet-tdt-0.6b-v3-fp16` model key; keep v2/v3 repos.
- Demo defaults updated: encoder `fp32`, decoder `int8`.
- Demo settings persist/restore via localStorage.
- Shared demo helpers introduced to reduce duplication.

### 3) Additional review-driven updates
- Encode `repoId` path segments in hub URLs.
- Gate hub preprocessor logs behind `options.verbose`.
- Revoke first-attempt blob URLs before demo FP32 retry.
- Remove unnecessary backend-triggered re-fetch in demo file listing effect.
- Narrow demo Vite `server.fs.allow` to `examples/shared`.
- Clarify docs:
  - demo README now distinguishes demo retry vs strict core API
  - root README FP16 `fromUrls` example uses stable `main` revision paths.
- Preserve original error chaining via `Error(..., { cause })` in `fromHub`.

## Verification

- `npm test` passes (**102 tests**)
- `npm run build` passes in `examples/demo`
- `npm run build` passes in `examples/hf-spaces-demo`

## Notes for Reviewers

This PR is intentionally additive: it preserves the full FP16 feature work and incorporates the latest corrections, not a replacement of prior FP16 scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FP16 quantization support; demo apps add Model Branch selector, persistent per-user settings, and dynamic encoder/decoder quant options per model/revision.
* **Bug Fixes**
  * Model loading adds FP16→FP32 fallback retry and clearer FP16-related errors/hints; improved WebGPU/decoder behavior.
* **Documentation**
  * Expanded FP16/WebGPU guidance, updated troubleshooting, examples, and FP16 usage snippets; public asset URLs updated.
* **Tests**
  * New tests for quantization resolution, FP16 flows, model loading fallback, and model key parsing.
* **Style / Chores**
  * Demo select styling tweaks and package version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest Delta (Post-Review)

- Fixed critical demo fallback diagnostic gap: when FP16 compile fails and FP32 retry download also fails, error now preserves both failure contexts.
- Added regression coverage: `tests/model-loader.test.mjs` verifies first error is preserved on retry-download failure.

## Deferred Review Items Tracked

- #81 Demo settings lazy init optimization (non-critical)
- #82 Test isolation for hub repo listing cache reset (future-proofing)
- #83 Hub internal options-forwarding cleanup (low risk)
