### PR TITLE
chore: Remove redundant CRITICAL FIX comment prefix

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -769,7 +769,7 @@ export class ParakeetModel {
       _logitsTensor?.dispose?.();
 
       if (maxId !== this.blankId) {
-        // CRITICAL FIX: Only update decoder state on non-blank token emission
+        // Only update decoder state on non-blank token emission
         // This matches the Python reference in onnx-asr/src/onnx_asr/asr.py line 212
         this._disposeDecoderState(decoderState, newState); // free old state tensors
         decoderState = newState;


### PR DESCRIPTION
Removes the "CRITICAL FIX:" prefix from a comment in `src/parakeet.js`. This prefix was flagging an already-implemented fix as an outstanding issue. The explanatory part of the comment remains intact.

---
*PR created automatically by Jules for task [16529728697073593055](https://jules.google.com/task/16529728697073593055) started by @ysdede*

## Summary by Sourcery

Chores:
- Clean up misleading comment prefix in parakeet decoder state update logic to better reflect current implementation status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation comment for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->