### PR TITLE
cleanup: remove unused skipCMVN parameter

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -523,7 +523,6 @@ export class ParakeetModel {
       temperature = 1.0, // Greedy decoding (1.0) is better for ASR than sampling (1.2)
       debug = false,
       enableProfiling = true,
-      skipCMVN = false,
       frameStride = 1,
       // NEW: Streaming options
       previousDecoderState = null,  // Accept state from previous chunk

--- a/tests/verify_transcribe_signature.mjs
+++ b/tests/verify_transcribe_signature.mjs
@@ -1,0 +1,26 @@
+import { ParakeetModel } from '../src/parakeet.js';
+
+async function test() {
+  console.log('Successfully imported ParakeetModel');
+  const proto = ParakeetModel.prototype;
+  console.log('Checking transcribe method...');
+  if (typeof proto.transcribe !== 'function') {
+    throw new Error('transcribe is not a function');
+  }
+
+  // We can't easily execute it fully without all mocks, but we can check if it exists.
+  console.log('transcribe method found.');
+
+  // To really verify destructuring, we can use a small trick:
+  // Get the source code of the function and check if skipCMVN is present.
+  const source = proto.transcribe.toString();
+  if (source.includes('skipCMVN')) {
+    throw new Error('transcribe source still contains skipCMVN');
+  }
+  console.log('Verified: skipCMVN is not in transcribe source.');
+}
+
+test().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/types/parakeet.d.ts
+++ b/types/parakeet.d.ts
@@ -30,7 +30,6 @@ export interface TranscribeOptions {
   temperature?: number;
   debug?: boolean;
   enableProfiling?: boolean;
-  skipCMVN?: boolean;
   frameStride?: number;
   previousDecoderState?: DecoderStateSnapshot | null;
   returnDecoderState?: boolean;


### PR DESCRIPTION
The `skipCMVN` parameter in the `transcribe` method was a destructured property from the options object that was not utilized in the function scope. It has been removed to improve code maintainability and readability. Correspondingly, it has also been removed from the `TranscribeOptions` interface in the TypeScript definition file.

---
*PR created automatically by Jules for task [18202064101693247717](https://jules.google.com/task/18202064101693247717) started by @ysdede*

## Summary by Sourcery

Remove an unused transcribe option and add a regression test to ensure it stays removed.

Enhancements:
- Remove the unused skipCMVN option from the transcribe method and its TypeScript definition to simplify the API surface.

Tests:
- Add a test that verifies the transcribe method exists and that its implementation no longer references skipCMVN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `skipCMVN` configuration option has been removed from the transcribe function. Code using this option will require updates.

* **Tests**
  * Added test coverage to verify the transcribe function signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->