### PR TITLE
add tests for usesRequestedFp16

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export async function fromUrls(cfg) {
   return ParakeetModel.fromUrls(cfg);
 }
 
-function usesRequestedFp16(options) {
+export function usesRequestedFp16(options) {
   return options?.encoderQuant === 'fp16' || options?.decoderQuant === 'fp16';
 }
 

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fromUrls, fromHub } from '../src/index.js';
+import { fromUrls, fromHub, usesRequestedFp16 } from '../src/index.js';
 import { ParakeetModel } from '../src/parakeet.js';
 import { getParakeetModel } from '../src/hub.js';
 
@@ -78,5 +78,33 @@ describe('index.js', () => {
     expect(error.message).toMatch(/compile failed/i);
     expect(getParakeetModel).toHaveBeenCalledTimes(1);
     expect(ParakeetModel.fromUrls).toHaveBeenCalledTimes(1);
+  });
+
+  describe('usesRequestedFp16', () => {
+    it('should return true if encoderQuant is fp16', () => {
+      expect(usesRequestedFp16({ encoderQuant: 'fp16' })).toBe(true);
+    });
+
+    it('should return true if decoderQuant is fp16', () => {
+      expect(usesRequestedFp16({ decoderQuant: 'fp16' })).toBe(true);
+    });
+
+    it('should return true if both are fp16', () => {
+      expect(usesRequestedFp16({ encoderQuant: 'fp16', decoderQuant: 'fp16' })).toBe(true);
+    });
+
+    it('should return false if neither is fp16', () => {
+      expect(usesRequestedFp16({ encoderQuant: 'fp32', decoderQuant: 'int8' })).toBe(false);
+    });
+
+    it('should return false if options is empty', () => {
+      expect(usesRequestedFp16({})).toBe(false);
+    });
+
+    it('should return false if options is null/undefined', () => {
+      expect(usesRequestedFp16(null)).toBe(false);
+      expect(usesRequestedFp16(undefined)).toBe(false);
+      expect(usesRequestedFp16()).toBe(false);
+    });
   });
 });

--- a/tests/verify_fp16_util.mjs
+++ b/tests/verify_fp16_util.mjs
@@ -1,0 +1,30 @@
+import { usesRequestedFp16 } from '../src/index.js';
+
+function assertEquals(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`FAIL: ${message} - Expected ${expected}, got ${actual}`);
+  }
+  console.log(`PASS: ${message}`);
+}
+
+function main() {
+  console.log('Running standalone verification for usesRequestedFp16...');
+
+  try {
+    assertEquals(usesRequestedFp16({ encoderQuant: 'fp16' }), true, 'encoderQuant: "fp16"');
+    assertEquals(usesRequestedFp16({ decoderQuant: 'fp16' }), true, 'decoderQuant: "fp16"');
+    assertEquals(usesRequestedFp16({ encoderQuant: 'fp16', decoderQuant: 'fp16' }), true, 'Both "fp16"');
+    assertEquals(usesRequestedFp16({ encoderQuant: 'fp32', decoderQuant: 'int8' }), false, 'Neither "fp16"');
+    assertEquals(usesRequestedFp16({}), false, 'Empty options');
+    assertEquals(usesRequestedFp16(null), false, 'null options');
+    assertEquals(usesRequestedFp16(undefined), false, 'undefined options');
+    assertEquals(usesRequestedFp16(), false, 'no arguments');
+
+    console.log('\nALL STANDALONE TESTS PASSED');
+  } catch (error) {
+    console.error('\n' + error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This PR addresses a testing gap for the `usesRequestedFp16` utility function in `src/index.js`.

### 🎯 What
The `usesRequestedFp16` function was previously untested. I have exported the function and added a complete suite of unit tests.

### 📊 Coverage
The new tests cover:
- `encoderQuant: 'fp16'` (returns true)
- `decoderQuant: 'fp16'` (returns true)
- Both set to `fp16` (returns true)
- Neither set to `fp16` (e.g. 'fp32', 'int8') (returns false)
- Empty options object (returns false)
- `null`, `undefined`, or missing options (returns false)

### ✨ Result
Increased test coverage for core utility logic in `src/index.js`, ensuring reliable detection of FP16 requests which triggers specific error hints in the `fromHub` factory.

---
*PR created automatically by Jules for task [15697676034613329478](https://jules.google.com/task/15697676034613329478) started by @ysdede*

## Summary by Sourcery

Add test coverage and public export for the FP16 detection utility used in index.js.

Enhancements:
- Export usesRequestedFp16 from src/index.js so it can be imported and tested externally.

Tests:
- Add unit tests verifying usesRequestedFp16 behavior across fp16, non-fp16, empty, null, undefined, and missing options inputs.
- Introduce a standalone verification script to manually validate usesRequestedFp16 behavior outside the main test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Utility function for checking FP16 support is now available in the public API for encoder and decoder configuration verification.

* **Tests**
  * Added comprehensive test coverage for the new utility with multiple scenarios covering various configuration combinations including null, undefined, and empty options.
  * Included standalone verification script for quick validation of the functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->