### PR TITLE
feat: add long-audio retranscription and decoder hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,34 @@ The demo flow in `examples/demo/src/App.jsx` is:
 Reference code:
 - `App` component in `examples/demo/src/App.jsx` (`loadModel` / `transcribeFile` flow)
 
-## Results
+## `transcribe()` options and result behavior
 
-`model.transcribe(...)` returns a `TranscribeResult` with this shape:
+`returnTimestamps` is **off by default**.  
+So: by default, `transcribe(...)` does **not** return meaningful timestamps.
+
+### `transcribe(audio, sampleRate, opts)` options
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `returnTimestamps` | `false` | Adds `start_time` / `end_time` to `tokens[]` and `words[]`. |
+| `returnConfidences` | `false` | Adds per-token/per-word confidence fields and detailed `confidence_scores`. |
+| `temperature` | `1.0` | Decoder temperature (`1.0` = greedy baseline behavior). |
+| `debug` | `false` | Enables debug logs; also causes `metrics` to be populated. |
+| `enableProfiling` | `true` | When `true`, returns timing/RTF in `metrics`. |
+| `skipCMVN` | `false` | Skips CMVN in preprocessing. |
+| `frameStride` | `1` | Decoder frame advance stride. |
+| `previousDecoderState` | `null` | Continue decoding from an earlier chunk (streaming/stateful usage). |
+| `returnDecoderState` | `false` | Includes `decoderState` in the result for next-call handoff. |
+| `timeOffset` | `0` | Offset (seconds) added to emitted timestamps. |
+| `returnTokenIds` | `false` | Includes `tokenIds` in result. |
+| `returnFrameIndices` | `false` | Includes `frameIndices` (token-to-encoder-frame alignment). |
+| `returnLogProbs` | `false` | Includes per-token `logProbs`. |
+| `returnTdtSteps` | `false` | Includes per-token `tdtSteps` (duration predictor outputs). |
+| `prefixSamples` | `0` | Enables incremental mel-cache reuse when prefix audio matches previous call. |
+| `precomputedFeatures` | `null` | Bypasses preprocessor by supplying already-computed mel features. |
+| `incremental` | `null` | Incremental decode cache config: `{ cacheKey, prefixSeconds }`. |
+
+### Result shape
 
 ```ts
 type TranscribeResult = {
@@ -167,9 +192,16 @@ type TranscribeResult = {
     tokenize_ms: number;
     total_ms: number;
     rtf: number;
-    mel_cache?: { cached_frames: number; new_frames: number };
+    mel_cache?: { cached_frames: number; new_frames: number } | null;
+    preprocessor_backend?: 'js' | 'onnx' | string; // runtime field
   } | null;
   is_final: boolean;
+  decoderState?: {
+    s1: Float32Array;
+    s2: Float32Array;
+    dims1: number[];
+    dims2: number[];
+  };
   tokenIds?: number[];
   frameIndices?: number[];
   logProbs?: number[];
@@ -177,9 +209,68 @@ type TranscribeResult = {
 };
 ```
 
-- Enable `returnTimestamps` for meaningful `start_time`/`end_time`.
-- Enable `returnConfidences` for per-token/per-word confidence fields.
-- Advanced alignment/debug outputs are opt-in: `returnTokenIds`, `returnFrameIndices`, `returnLogProbs`, `returnTdtSteps`.
+### What you get by default vs opt-in
+
+| Call options | `words` | `tokens` | `confidence_scores` | `metrics` |
+| --- | --- | --- | --- | --- |
+| default (`{}`) | `[]` (empty) | omitted | omitted | present (`enableProfiling` default is `true`) |
+| `{ returnTimestamps: true }` | timestamped words | timestamped tokens | minimal (`frame/frame_avg/overall_log_prob` are `null`) | present by default |
+| `{ returnConfidences: true }` | words with `confidence` | tokens with `confidence` | detailed token/word/frame confidence stats | present by default |
+| `{ returnTimestamps: true, returnConfidences: true }` | timestamped + confidence | timestamped + confidence | detailed token/word/frame confidence stats | present by default |
+
+Notes:
+- `start_time` / `end_time` are only meaningful when `returnTimestamps: true`.
+- Advanced alignment/debug arrays are opt-in: `returnTokenIds`, `returnFrameIndices`, `returnLogProbs`, `returnTdtSteps`.
+- If `enableProfiling: false` and `debug: false`, then `metrics` is `null`.
+- `timeOffset` must be finite.
+- Audio buffers passed to `transcribe(...)`, `computeFeatures(...)`, and `transcribeLongAudio(...)` must contain finite samples.
+
+## Long-audio retranscription
+
+Use `transcribeLongAudio(...)` when you want built-in sentence-aware windowing and chunk assembly for long recordings.
+
+```js
+const result = await model.transcribeLongAudio(pcm, 16000, {
+  returnTimestamps: true,
+  chunkLengthS: 30,
+  timeOffset: 12.5,
+});
+
+console.log(result.text);
+console.log(result.chunks);
+```
+
+### `transcribeLongAudio(audio, sampleRate, opts)` options
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `returnTimestamps` | `false` | `true` returns sentence-like chunks; `'word'` returns per-word chunks. |
+| `chunkLengthS` | `0` | Fixed window length in seconds. `0` enables auto window sizing for long inputs. |
+| `timeOffset` | `0` | Offset (seconds) added to returned chunk/word timestamps. |
+| other `transcribe()` options | varies | Forwarded to each internal transcription window. |
+
+### Result shape
+
+```ts
+type LongAudioTranscribeResult = {
+  text: string;
+  words?: Array<{
+    text: string;
+    start_time: number;
+    end_time: number;
+    confidence?: number;
+  }>;
+  chunks?: Array<{
+    text: string;
+    timestamp: [number, number];
+  }>;
+};
+```
+
+Notes:
+- `returnTimestamps: true` returns merged sentence-like chunks.
+- `returnTimestamps: 'word'` returns per-word chunks while still including merged `words`.
+- For shorter clips, `transcribeLongAudio(...)` falls back to a single internal `transcribe(...)` call.
 
 ## Real-time streaming (Keet)
 

--- a/src/long_audio.js
+++ b/src/long_audio.js
@@ -374,6 +374,9 @@ async function runAutoSentenceWindowing({
  */
 export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 16000, opts = {}) {
   validateAudio(audio);
+  if (typeof sampleRate !== 'number' || !Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error('ParakeetModel.transcribeLongAudio expected `sampleRate` to be a positive finite number.');
+  }
 
   const {
     returnTimestamps = false,
@@ -381,6 +384,9 @@ export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 1
     timeOffset = 0,
     ...transcribeOptions
   } = opts;
+  if (typeof timeOffset !== 'number' || !Number.isFinite(timeOffset) || timeOffset < 0) {
+    throw new Error('ParakeetModel.transcribeLongAudio expected `timeOffset` to be a finite non-negative number.');
+  }
 
   const wantWordTimestamps = returnTimestamps === 'word';
   const wantTimestampChunks = returnTimestamps === true || wantWordTimestamps;

--- a/src/long_audio.js
+++ b/src/long_audio.js
@@ -1,0 +1,441 @@
+const AUTO_WINDOW_THRESHOLD_S = 180;
+const MIN_CHUNK_LENGTH_S = 20;
+const MAX_CHUNK_LENGTH_S = 180;
+const AUTO_CHUNK_LENGTH_S = 90;
+const AUTO_WINDOW_FALLBACK_OVERLAP_S = 10;
+const AUTO_WINDOW_EPSILON_S = 1e-6;
+const SEGMENT_DEDUP_TOLERANCE_S = 0.15;
+const CURSOR_MIN_ADVANCE_S = 1.0;
+const CURSOR_GAP_THRESHOLD_S = 0.2;
+const CURSOR_SNAP_WINDOW_S = 0.5;
+
+function validateAudio(audio) {
+  if (!(audio instanceof Float32Array || audio instanceof Float64Array)) {
+    throw new TypeError('ParakeetModel.transcribeLongAudio expected audio to be Float32Array or Float64Array.');
+  }
+  for (let i = 0; i < audio.length; ++i) {
+    if (!Number.isFinite(audio[i])) {
+      throw new Error(`ParakeetModel.transcribeLongAudio expected finite audio samples; found ${audio[i]} at index ${i}.`);
+    }
+  }
+}
+
+function normalizeChunkLengthS(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) {
+    return 0;
+  }
+  return Math.max(MIN_CHUNK_LENGTH_S, Math.min(MAX_CHUNK_LENGTH_S, num));
+}
+
+function joinTimedWords(words) {
+  let text = '';
+  for (const word of words) {
+    const part = word?.text ?? '';
+    if (!part) continue;
+    if (!text) {
+      text = part;
+    } else if (/^[,.;:!?)}\]]+$/.test(part)) {
+      text += part;
+    } else {
+      text += ` ${part}`;
+    }
+  }
+  return text;
+}
+
+function buildWordChunks(words) {
+  return words.map((word) => ({
+    text: word.text,
+    timestamp: [word.start_time, word.end_time],
+  }));
+}
+
+function normalizeMergedWordText(text) {
+  return String(text ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/^[("'“‘\[{]+/g, '')
+    .replace(/[.,!?;:)"'”’\]}]+$/g, '')
+    .trim();
+}
+
+function normalizeRawMergedWordText(text) {
+  return String(text ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .trim();
+}
+
+function dedupeMergedWords(words) {
+  const merged = [];
+  for (const word of words) {
+    const prev = merged.at(-1);
+    const prevText = normalizeMergedWordText(prev?.text);
+    const wordText = normalizeMergedWordText(word?.text);
+
+    if (
+      prev &&
+      prevText === wordText &&
+      (
+        prevText.length > 0 ||
+        normalizeRawMergedWordText(prev.text) === normalizeRawMergedWordText(word.text)
+      ) &&
+      word.start_time < prev.end_time
+    ) {
+      const prevDuration = prev.end_time - prev.start_time;
+      const nextDuration = word.end_time - word.start_time;
+      if (nextDuration > prevDuration) {
+        merged[merged.length - 1] = word;
+      }
+      continue;
+    }
+    merged.push(word);
+  }
+  return merged;
+}
+
+const STRONG_SENTENCE_END_REGEX = /[!?…](?:["')\]]+)?$/u;
+const PERIOD_SENTENCE_END_REGEX = /\.(?:["')\]]+)?$/u;
+const TRAILING_CLOSERS_REGEX = /["')\]]+$/gu;
+const LEADING_OPENERS_REGEX = /^[("'“‘\[{]+/u;
+const DOTTED_ACRONYM_REGEX = /^(?:[A-Z]\.){2,}$/;
+const SINGLE_LETTER_ENUM_REGEX = /^[A-Z]\.$/;
+const ROMAN_ENUM_REGEX = /^(?:[IVXLCDM]+)\.$/i;
+const NUMERIC_ENUM_REGEX = /^\d+\.$/;
+const FALLBACK_SEGMENT_GAP_S = 3.0;
+const NON_BREAKING_PERIOD_WORDS = new Set([
+  'mr.',
+  'mrs.',
+  'ms.',
+  'dr.',
+  'prof.',
+  'sr.',
+  'jr.',
+  'vs.',
+  'etc.',
+  'e.g.',
+  'i.e.',
+]);
+
+function stripTrailingClosers(text) {
+  return String(text ?? '').replace(TRAILING_CLOSERS_REGEX, '');
+}
+
+function looksLikeSentenceStart(text) {
+  const cleaned = String(text ?? '').replace(LEADING_OPENERS_REGEX, '');
+  return /^[A-Z]/.test(cleaned);
+}
+
+function shouldEndSentenceAfterWord(currentWord, nextWord, gapS = 0) {
+  if (!nextWord) return false;
+  if (gapS >= FALLBACK_SEGMENT_GAP_S) return true;
+
+  const currentText = String(currentWord?.text ?? '');
+  if (!currentText) return false;
+  if (STRONG_SENTENCE_END_REGEX.test(currentText)) return true;
+  if (!PERIOD_SENTENCE_END_REGEX.test(currentText)) return false;
+
+  const stripped = stripTrailingClosers(currentText);
+  const lowered = stripped.toLowerCase();
+  if (
+    NON_BREAKING_PERIOD_WORDS.has(lowered) ||
+    DOTTED_ACRONYM_REGEX.test(stripped) ||
+    SINGLE_LETTER_ENUM_REGEX.test(stripped) ||
+    ROMAN_ENUM_REGEX.test(stripped) ||
+    NUMERIC_ENUM_REGEX.test(stripped)
+  ) {
+    return false;
+  }
+
+  return looksLikeSentenceStart(nextWord.text);
+}
+
+function partitionWordsIntoSegments(words) {
+  if (!Array.isArray(words) || words.length === 0) {
+    return [];
+  }
+
+  const segments = [];
+  let current = [];
+  for (let i = 0; i < words.length; ++i) {
+    const word = words[i];
+    current.push(word);
+
+    const nextWord = words[i + 1] ?? null;
+    const gapS = nextWord ? Math.max(0, nextWord.start_time - word.end_time) : 0;
+    if (shouldEndSentenceAfterWord(word, nextWord, gapS)) {
+      segments.push({
+        words: current,
+        text: joinTimedWords(current),
+        timestamp: [current[0].start_time, current[current.length - 1].end_time],
+      });
+      current = [];
+    }
+  }
+
+  if (current.length > 0) {
+    segments.push({
+      words: current,
+      text: joinTimedWords(current),
+      timestamp: [current[0].start_time, current[current.length - 1].end_time],
+    });
+  }
+
+  return segments;
+}
+
+function buildSegmentChunks(words, text = '') {
+  if (!Array.isArray(words) || words.length === 0) {
+    return text ? [{ text, timestamp: [0, 0] }] : [];
+  }
+
+  return partitionWordsIntoSegments(words).map((segment) => ({
+    text: segment.text,
+    timestamp: segment.timestamp,
+  }));
+}
+
+function flattenSegmentWords(segments) {
+  return segments.flatMap((segment) => segment.words);
+}
+
+function mergePendingAndCurrentWords(pendingWords, currentWords) {
+  const normalizedPendingWords = Array.isArray(pendingWords) ? pendingWords : [];
+  const normalizedCurrentWords = Array.isArray(currentWords) ? currentWords : [];
+
+  if (normalizedPendingWords.length === 0) {
+    return dedupeMergedWords(normalizedCurrentWords);
+  }
+  if (normalizedCurrentWords.length === 0) {
+    return dedupeMergedWords(normalizedPendingWords);
+  }
+
+  const pendingStart = normalizedPendingWords[0].start_time;
+  const currentStart = normalizedCurrentWords[0].start_time;
+  if (currentStart <= pendingStart + AUTO_WINDOW_EPSILON_S) {
+    return dedupeMergedWords(normalizedCurrentWords);
+  }
+
+  return dedupeMergedWords([...normalizedPendingWords, ...normalizedCurrentWords]);
+}
+
+function normalizeSegmentText(text) {
+  return String(text ?? '')
+    .normalize('NFKC')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function isDuplicateFinalizedSegment(finalizedSegments, segment) {
+  const normalized = normalizeSegmentText(segment.text);
+  if (!normalized) return false;
+
+  return finalizedSegments.some(
+    (candidate) =>
+      normalizeSegmentText(candidate.text) === normalized &&
+      Math.abs(candidate.timestamp[1] - segment.timestamp[1]) < SEGMENT_DEDUP_TOLERANCE_S,
+  );
+}
+
+function appendFinalizedSegment(finalizedSegments, segment) {
+  if (!isDuplicateFinalizedSegment(finalizedSegments, segment)) {
+    finalizedSegments.push(segment);
+  }
+}
+
+function relocateCursorToNearbyGap(targetS, words) {
+  let best = targetS;
+  let bestDist = CURSOR_SNAP_WINDOW_S + 1;
+
+  for (let i = 0; i < words.length - 1; ++i) {
+    const current = words[i];
+    const next = words[i + 1];
+    const gapStart = current.end_time;
+    const gapEnd = next.start_time;
+    const gap = gapEnd - gapStart;
+    if (gap < CURSOR_GAP_THRESHOLD_S) continue;
+
+    for (const candidate of [gapStart, gapEnd]) {
+      if (candidate + AUTO_WINDOW_EPSILON_S < targetS) continue;
+      const dist = candidate - targetS;
+      if (dist <= CURSOR_SNAP_WINDOW_S && dist < bestDist) {
+        best = candidate;
+        bestDist = dist;
+      }
+    }
+  }
+
+  return best;
+}
+
+async function runAutoSentenceWindowing({
+  audio,
+  samplingRate,
+  chunkLengthS,
+  baseTimeOffset,
+  transcribeWindow,
+}) {
+  const audioDurationS = audio.length / samplingRate;
+  const fallbackOverlapS = Math.min(AUTO_WINDOW_FALLBACK_OVERLAP_S, Math.max(0, chunkLengthS - 1));
+  const fallbackAdvanceS = Math.max(1, chunkLengthS - fallbackOverlapS);
+  const maxWindows = Math.max(
+    4,
+    Math.ceil(Math.max(0, audioDurationS - chunkLengthS) / CURSOR_MIN_ADVANCE_S) + 2,
+  );
+
+  const finalizedSegments = [];
+  let pendingWords = [];
+  let lastTextFallback = '';
+  let startS = 0;
+  let shouldMergePending = false;
+
+  for (let windowIndex = 0; windowIndex < maxWindows && startS < audioDurationS - AUTO_WINDOW_EPSILON_S; ++windowIndex) {
+    const endS = Math.min(audioDurationS, startS + chunkLengthS);
+    const startSample = Math.max(0, Math.min(audio.length - 1, Math.floor(startS * samplingRate)));
+    const endSample = Math.max(startSample + 1, Math.min(audio.length, Math.ceil(endS * samplingRate)));
+    const windowAudio = audio.subarray(startSample, endSample);
+    const isLastWindow = endS >= audioDurationS - AUTO_WINDOW_EPSILON_S;
+
+    const output = await transcribeWindow(windowAudio, baseTimeOffset + startS);
+    lastTextFallback = output.text ?? lastTextFallback;
+
+    const currentWords = Array.isArray(output.words) ? output.words : [];
+    const windowWords = shouldMergePending
+      ? mergePendingAndCurrentWords(pendingWords, currentWords)
+      : dedupeMergedWords(currentWords);
+    const segments = partitionWordsIntoSegments(windowWords);
+
+    if (isLastWindow) {
+      for (const segment of segments) {
+        appendFinalizedSegment(finalizedSegments, segment);
+      }
+      pendingWords = [];
+      break;
+    }
+
+    if (segments.length > 1) {
+      const pendingSegment = segments[segments.length - 1];
+      const pendingStartS = pendingSegment.timestamp[0];
+      const pendingRelativeStartS = Math.max(0, pendingStartS - baseTimeOffset);
+      if (pendingRelativeStartS >= startS + CURSOR_MIN_ADVANCE_S - AUTO_WINDOW_EPSILON_S) {
+        const readySegments = segments.slice(0, -1);
+        for (const segment of readySegments) {
+          appendFinalizedSegment(finalizedSegments, segment);
+        }
+
+        pendingWords = dedupeMergedWords(pendingSegment.words);
+        const nextStartS = Math.min(
+          audioDurationS,
+          Math.max(0, relocateCursorToNearbyGap(pendingStartS, windowWords) - baseTimeOffset),
+        );
+        shouldMergePending = nextStartS > pendingRelativeStartS + AUTO_WINDOW_EPSILON_S;
+        if (nextStartS > startS + AUTO_WINDOW_EPSILON_S) {
+          startS = nextStartS;
+          continue;
+        }
+      }
+    }
+
+    pendingWords = windowWords;
+    shouldMergePending = true;
+
+    const fallbackStartS = Math.min(audioDurationS, startS + fallbackAdvanceS);
+    if (fallbackStartS <= startS + AUTO_WINDOW_EPSILON_S) {
+      break;
+    }
+    startS = fallbackStartS;
+  }
+
+  const words = dedupeMergedWords([...flattenSegmentWords(finalizedSegments), ...pendingWords]);
+  const text = words.length > 0 ? joinTimedWords(words) : String(lastTextFallback ?? '').trim();
+  const chunks = buildSegmentChunks(words, text);
+
+  return { text, words, chunks };
+}
+
+/**
+ * @param {import('./parakeet.js').ParakeetModel} model
+ * @param {Float32Array|Float64Array} audio
+ * @param {number} sampleRate
+ * @param {object} [opts]
+ * @param {boolean|'word'} [opts.returnTimestamps=false]
+ * @param {number} [opts.chunkLengthS=0]
+ * @param {boolean} [opts.returnConfidences=false]
+ * @param {boolean} [opts.debug=false]
+ * @param {boolean} [opts.enableProfiling=true]
+ * @param {number} [opts.temperature=1.0]
+ * @param {boolean} [opts.skipCMVN=false]
+ * @param {number} [opts.timeOffset=0]
+ * @returns {Promise<{text: string, chunks?: Array<{ text: string, timestamp: [number, number] }>, words?: Array<{ text: string, start_time: number, end_time: number, confidence?: number }>}>}
+ */
+export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 16000, opts = {}) {
+  validateAudio(audio);
+
+  const {
+    returnTimestamps = false,
+    chunkLengthS = 0,
+    timeOffset = 0,
+    ...transcribeOptions
+  } = opts;
+
+  const wantWordTimestamps = returnTimestamps === 'word';
+  const wantTimestampChunks = returnTimestamps === true || wantWordTimestamps;
+  const normalizedChunkLengthS = normalizeChunkLengthS(chunkLengthS);
+  const audioDurationS = audio.length / sampleRate;
+  const autoWindowing = normalizedChunkLengthS <= 0 && audioDurationS > AUTO_WINDOW_THRESHOLD_S;
+  const effectiveChunkLengthS = normalizedChunkLengthS > 0
+    ? normalizedChunkLengthS
+    : autoWindowing
+      ? AUTO_CHUNK_LENGTH_S
+      : 0;
+
+  const transcribeWindow = async (windowAudio, windowTimeOffset) => {
+    const output = await model.transcribe(windowAudio, sampleRate, {
+      ...transcribeOptions,
+      returnTimestamps: true,
+      timeOffset: windowTimeOffset,
+    });
+    return {
+      text: output.utterance_text ?? '',
+      words: Array.isArray(output.words) ? output.words : [],
+    };
+  };
+
+  if (effectiveChunkLengthS > 0) {
+    const merged = await runAutoSentenceWindowing({
+      audio,
+      samplingRate: sampleRate,
+      chunkLengthS: effectiveChunkLengthS,
+      baseTimeOffset: timeOffset,
+      transcribeWindow,
+    });
+
+    const result = { text: merged.text };
+    if (wantTimestampChunks) {
+      result.words = merged.words;
+      result.chunks = wantWordTimestamps ? buildWordChunks(merged.words) : merged.chunks;
+    }
+    return result;
+  }
+
+  const output = await model.transcribe(audio, sampleRate, {
+    ...transcribeOptions,
+    returnTimestamps: wantTimestampChunks,
+    timeOffset,
+  });
+  const text = output.utterance_text ?? '';
+  if (!wantTimestampChunks) {
+    return { text };
+  }
+
+  const words = Array.isArray(output.words) ? output.words : [];
+  return {
+    text,
+    words,
+    chunks: wantWordTimestamps ? buildWordChunks(words) : buildSegmentChunks(words, text),
+  };
+}

--- a/src/long_audio.js
+++ b/src/long_audio.js
@@ -396,6 +396,7 @@ export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 1
   const transcribeWindow = async (windowAudio, windowTimeOffset) => {
     const output = await model.transcribe(windowAudio, sampleRate, {
       ...transcribeOptions,
+      _skipAudioValidation: true,
       returnTimestamps: true,
       timeOffset: windowTimeOffset,
     });
@@ -424,6 +425,7 @@ export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 1
 
   const output = await model.transcribe(audio, sampleRate, {
     ...transcribeOptions,
+    _skipAudioValidation: true,
     returnTimestamps: wantTimestampChunks,
     timeOffset,
   });

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -2,6 +2,18 @@ import { initOrt } from './backend.js';
 import { ParakeetTokenizer } from './tokenizer.js';
 import { OnnxPreprocessor } from './preprocessor.js';
 import { JsPreprocessor, IncrementalMelProcessor, MEL_CONSTANTS } from './mel.js';
+import { transcribeLongAudioWithChunks } from './long_audio.js';
+
+function validateFiniteAudioSamples(audio, methodName) {
+  if (!(audio instanceof Float32Array || audio instanceof Float64Array)) {
+    return;
+  }
+  for (let i = 0; i < audio.length; ++i) {
+    if (!Number.isFinite(audio[i])) {
+      throw new Error(`${methodName} expected finite audio samples; found ${audio[i]} at index ${i}.`);
+    }
+  }
+}
 
 /**
  * Lightweight Parakeet model wrapper designed for browser usage.
@@ -285,19 +297,47 @@ export class ParakeetModel {
 
     const out = await this.joinerSession.run(feeds);
     const logits = out['outputs'];
+    const outputState1 = out['output_states_1'];
+    const outputState2 = out['output_states_2'];
+    const seenOutputs = new Set();
+    for (const value of Object.values(out)) {
+      if (!value || typeof value.dispose !== 'function' || seenOutputs.has(value)) continue;
+      seenOutputs.add(value);
+      if (value === logits || value === outputState1 || value === outputState2) continue;
+      value.dispose();
+    }
     // Note: _targetTensor and _targetLenTensor are intentionally NOT disposed here.
     // They wrap a shared Int32Array (_targetIdArray / _targetLenArray) that is mutated
     // each call. ORT-WASM does not copy the data on Tensor creation, so these tensors
     // have no separate WASM allocation to leak — disposing them would be wrong.
 
     const vocab = this.tokenizer.id2token.length;
-    const totalDim = logits.dims[3];
+    if (!logits || !logits.data || typeof logits.data.subarray !== 'function') {
+      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
+      throw new Error('ParakeetModel decoder output did not include a valid `outputs` tensor.');
+    }
+    if (!outputState1 || !outputState2) {
+      logits.dispose?.();
+      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
+      throw new Error('ParakeetModel decoder output did not include both decoder state tensors.');
+    }
     const data = logits.data;
+    if (data.length < vocab) {
+      logits.dispose?.();
+      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
+      throw new Error(`ParakeetModel decoder output is too small (${data.length}) for vocab size ${vocab}.`);
+    }
+    const totalDim = data.length;
 
     // subarray(): zero-copy view into joiner output buffer.
     // Do NOT mutate tokenLogits/durLogits without copying first (.slice()).
     const tokenLogits = data.subarray(0, vocab);
     const durLogits = data.subarray(vocab, totalDim);
+    if (durLogits.length === 0) {
+      logits.dispose?.();
+      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
+      throw new Error('ParakeetModel decoder output is missing required TDT duration logits.');
+    }
 
     let step = 0;
     if (durLogits.length) {
@@ -306,8 +346,8 @@ export class ParakeetModel {
     }
 
     const newState = {
-      state1: out['output_states_1'] || state1,
-      state2: out['output_states_2'] || state2,
+      state1: outputState1,
+      state2: outputState2,
     };
 
     return { tokenLogits, step, newState, _logitsTensor: logits };
@@ -355,6 +395,7 @@ export class ParakeetModel {
    */
   async computeFeatures(audio, sampleRate = 16000, opts = {}) {
     const { prefixSamples = 0 } = opts;
+    validateFiniteAudioSamples(audio, 'ParakeetModel.computeFeatures');
 
     // Use incremental mel processor if available and prefix is specified
     if (this._incrementalMel && prefixSamples > 0) {
@@ -540,6 +581,13 @@ export class ParakeetModel {
       precomputedFeatures = null,    // { features: Float32Array, T: number, melBins: number }
     } = opts;
 
+    if (!Number.isFinite(timeOffset)) {
+      throw new Error('ParakeetModel.transcribe expected `timeOffset` to be a finite number.');
+    }
+    if (!precomputedFeatures) {
+      validateFiniteAudioSamples(audio, 'ParakeetModel.transcribe');
+    }
+
     const perfEnabled = debug || enableProfiling; // collect timings & populate result.metrics (default: true for backward compat)
     let t0, tPreproc = 0, tEncode = 0, tDecode = 0, tToken = 0;
     if (perfEnabled) t0 = performance.now();
@@ -594,19 +642,21 @@ export class ParakeetModel {
     const encoderLength = validLength ?? T;
     const lenTensor = new this.ort.Tensor('int64', BigInt64Array.from([BigInt(encoderLength)]), [1]);
     let enc;
-    if (perfEnabled) {
-      const s = performance.now();
-      const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
-      tEncode = performance.now() - s;
-      enc = encOut['outputs'] ?? Object.values(encOut)[0];
-    } else {
-      const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
-      enc = encOut['outputs'] ?? Object.values(encOut)[0];
+    try {
+      if (perfEnabled) {
+        const s = performance.now();
+        const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
+        tEncode = performance.now() - s;
+        enc = encOut['outputs'] ?? Object.values(encOut)[0];
+      } else {
+        const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
+        enc = encOut['outputs'] ?? Object.values(encOut)[0];
+      }
+    } finally {
+      // Dispose per-call input tensors even when encoder execution fails.
+      input.dispose?.();
+      lenTensor.dispose?.();
     }
-
-    // Dispose per-call input tensors (data is now in encOut; inputs no longer needed)
-    input.dispose?.();
-    lenTensor.dispose?.();
 
     // Transpose encoder output [B, D, T] -> [T, D] for B=1
     const [, D, Tenc] = enc.dims;
@@ -650,7 +700,7 @@ export class ParakeetModel {
     const ids = [];
     const tokenTimes = [];
     const tokenConfs = [];
-    const frameConfs = [];
+    const frameConfidenceStats = new Map();
     let overallLogProb = 0;
 
     // NEW: Frame-aligned streaming data
@@ -760,7 +810,13 @@ export class ParakeetModel {
         logProbVal = (maxLogit * invTemp) - maxVal - Math.log(sumExp);
 
         if (returnConfidences) {
-          frameConfs.push(confVal);
+          const stats = frameConfidenceStats.get(t);
+          if (stats) {
+            stats.sum += confVal;
+            stats.count += 1;
+          } else {
+            frameConfidenceStats.set(t, { sum: confVal, count: 1 });
+          }
           overallLogProb += Math.log(confVal);
         }
       }
@@ -786,9 +842,10 @@ export class ParakeetModel {
 
         if (returnTimestamps) {
           const durFrames = step > 0 ? step : 1;
+          const endFrame = Math.min(Tenc, t + Math.max(1, durFrames));
           // Use effectiveTimeOffset for streaming mode
           const start = effectiveTimeOffset + (t * TIME_STRIDE);
-          const end = effectiveTimeOffset + ((t + durFrames) * TIME_STRIDE);
+          const end = effectiveTimeOffset + (endFrame * TIME_STRIDE);
           tokenTimes.push([start, end]);
         }
         if (returnConfidences) tokenConfs.push(confVal);
@@ -945,6 +1002,10 @@ export class ParakeetModel {
       console.table({ Preprocess: `${tPreproc.toFixed(1)} ms`, Encode: `${tEncode.toFixed(1)} ms`, Decode: `${tDecode.toFixed(1)} ms`, Tokenize: `${tToken.toFixed(1)} ms`, Total: `${total.toFixed(1)} ms` });
     }
 
+    const frameConfs = Array.from(frameConfidenceStats.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([, stats]) => stats.sum / stats.count);
+
     const result = {
       utterance_text: text,
       words,
@@ -1014,6 +1075,20 @@ export class ParakeetModel {
    */
   createStreamingTranscriber(opts = {}) {
     return new StatefulStreamingTranscriber(this, opts);
+  }
+
+  /**
+   * Transcribe long-form audio with sentence-aware windowing and chunk assembly.
+   * This is intended for full recordings where a single `transcribe()` call is
+   * less convenient than a built-in windowing helper.
+   *
+   * @param {Float32Array|Float64Array} audio - Full audio buffer.
+   * @param {number} sampleRate - Sample rate (default 16000).
+   * @param {Object} opts - Long-audio transcription options.
+   * @returns {Promise<{ text: string, words?: Array<{ text: string, start_time: number, end_time: number, confidence?: number }>, chunks?: Array<{ text: string, timestamp: [number, number] }> }>}
+   */
+  async transcribeLongAudio(audio, sampleRate = 16000, opts = {}) {
+    return transcribeLongAudioWithChunks(this, audio, sampleRate, opts);
   }
 
   /**
@@ -1236,7 +1311,11 @@ export class MelFeatureCache {
    * @param {number} opts.maxCacheSizeMB - Maximum cache size in MB (default 50)
    */
   constructor(opts = {}) {
-    this.maxCacheSizeMB = opts.maxCacheSizeMB || 50;
+    const maxCacheSizeMB = opts.maxCacheSizeMB ?? 50;
+    if (!Number.isFinite(maxCacheSizeMB) || maxCacheSizeMB <= 0) {
+      throw new Error('MelFeatureCache expected `maxCacheSizeMB` to be a positive number.');
+    }
+    this.maxCacheSizeMB = maxCacheSizeMB;
     this.cache = new Map();  // key → { features, T, melBins, timestamp }
     this.currentSizeMB = 0;
   }
@@ -1254,7 +1333,9 @@ export class MelFeatureCache {
     // MurmurHash3-style 32-bit mix helper
     const mix32 = (h, v) => {
       // Quantise float to 16-bit signed integer range
-      let k = Math.floor(v * 32768) & 0xffff;
+      const sample = Number.isFinite(v) ? v : 0;
+      const quantized = Math.max(-32768, Math.min(32767, Math.round(sample * 32768)));
+      let k = quantized & 0xffff;
       k = Math.imul(k, 0xcc9e2d51);
       k = (k << 15) | (k >>> 17);
       k = Math.imul(k, 0x1b873593);
@@ -1274,14 +1355,8 @@ export class MelFeatureCache {
     // Seed with length so differently-sized arrays can never collide
     let h = n | 0;
 
-    // Always include boundary samples (catches edits at the start/end)
-    const boundary = Math.min(4, n);
-    for (let i = 0; i < boundary; i++) h = mix32(h, audio[i]);
-    for (let i = Math.max(boundary, n - 4); i < n; i++) h = mix32(h, audio[i]);
-
-    // Uniform interior sampling — ~128 evenly spaced positions
-    const stride = Math.max(1, Math.floor(n / 128));
-    for (let i = 0; i < n; i += stride) h = mix32(h, audio[i]);
+    // Hash all samples to minimize false cache hits across similar waveforms.
+    for (let i = 0; i < n; i++) h = mix32(h, audio[i]);
 
     return `${n}_${fmix32(h)}`;
   }

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -312,20 +312,32 @@ export class ParakeetModel {
     // have no separate WASM allocation to leak — disposing them would be wrong.
 
     const vocab = this.tokenizer.id2token.length;
+    const failDecoderStep = (message) => {
+      logits?.dispose?.();
+
+      const disposed = new Set();
+      const disposeUniqueState = (state) => {
+        if (!state) return;
+        for (const tensor of [state.state1, state.state2]) {
+          if (!tensor || tensor === this._combState1 || tensor === this._combState2 || disposed.has(tensor)) continue;
+          disposed.add(tensor);
+          tensor.dispose?.();
+        }
+      };
+
+      disposeUniqueState({ state1: outputState1, state2: outputState2 });
+      disposeUniqueState(currentState);
+      throw new Error(message);
+    };
     if (!logits || !logits.data || typeof logits.data.subarray !== 'function') {
-      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
-      throw new Error('ParakeetModel decoder output did not include a valid `outputs` tensor.');
+      failDecoderStep('ParakeetModel decoder output did not include a valid `outputs` tensor.');
     }
     if (!outputState1 || !outputState2) {
-      logits.dispose?.();
-      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
-      throw new Error('ParakeetModel decoder output did not include both decoder state tensors.');
+      failDecoderStep('ParakeetModel decoder output did not include both decoder state tensors.');
     }
     const data = logits.data;
     if (data.length < vocab) {
-      logits.dispose?.();
-      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
-      throw new Error(`ParakeetModel decoder output is too small (${data.length}) for vocab size ${vocab}.`);
+      failDecoderStep(`ParakeetModel decoder output is too small (${data.length}) for vocab size ${vocab}.`);
     }
     const totalDim = data.length;
 
@@ -334,9 +346,7 @@ export class ParakeetModel {
     const tokenLogits = data.subarray(0, vocab);
     const durLogits = data.subarray(vocab, totalDim);
     if (durLogits.length === 0) {
-      logits.dispose?.();
-      this._disposeDecoderState({ state1: outputState1, state2: outputState2 }, currentState);
-      throw new Error('ParakeetModel decoder output is missing required TDT duration logits.');
+      failDecoderStep('ParakeetModel decoder output is missing required TDT duration logits.');
     }
 
     let step = 0;

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -394,8 +394,10 @@ export class ParakeetModel {
    * @returns {{features: Float32Array, T: number, melBins: number, cached?: boolean, cachedFrames?: number, newFrames?: number}}
    */
   async computeFeatures(audio, sampleRate = 16000, opts = {}) {
-    const { prefixSamples = 0 } = opts;
-    validateFiniteAudioSamples(audio, 'ParakeetModel.computeFeatures');
+    const { prefixSamples = 0, _skipAudioValidation = false } = opts;
+    if (!_skipAudioValidation) {
+      validateFiniteAudioSamples(audio, 'ParakeetModel.computeFeatures');
+    }
 
     // Use incremental mel processor if available and prefix is specified
     if (this._incrementalMel && prefixSamples > 0) {
@@ -579,13 +581,11 @@ export class ParakeetModel {
       prefixSamples = 0,            // Number of leading samples identical to previous call
       // Pre-computed mel features (bypass preprocessor entirely)
       precomputedFeatures = null,    // { features: Float32Array, T: number, melBins: number }
+      _skipAudioValidation = false,  // Internal: long-audio helpers can skip re-validating already checked windows
     } = opts;
 
     if (!Number.isFinite(timeOffset)) {
       throw new Error('ParakeetModel.transcribe expected `timeOffset` to be a finite number.');
-    }
-    if (!precomputedFeatures) {
-      validateFiniteAudioSamples(audio, 'ParakeetModel.transcribe');
     }
 
     const perfEnabled = debug || enableProfiling; // collect timings & populate result.metrics (default: true for backward compat)
@@ -606,14 +606,14 @@ export class ParakeetModel {
       console.log(`[Parakeet] Preprocessor: mel-worker (precomputed ${T} frames × ${melBins} mel bins, 0 ms)`);
     } else if (perfEnabled) {
       const s = performance.now();
-      ({ features, T, melBins, validLength, ...melCacheInfo } = await this.computeFeatures(audio, sampleRate, { prefixSamples }));
+      ({ features, T, melBins, validLength, ...melCacheInfo } = await this.computeFeatures(audio, sampleRate, { prefixSamples, _skipAudioValidation }));
       tPreproc = performance.now() - s;
       const cacheStr = melCacheInfo?.cached
         ? ` (cached: ${melCacheInfo.cachedFrames} frames, new: ${melCacheInfo.newFrames} frames)`
         : '';
       console.log(`[Parakeet] Preprocessor: ${preprocessorPath}, ${T} frames × ${melBins} mel bins, ${tPreproc.toFixed(1)} ms${cacheStr}`);
     } else {
-      ({ features, T, melBins, validLength, ...melCacheInfo } = await this.computeFeatures(audio, sampleRate, { prefixSamples }));
+      ({ features, T, melBins, validLength, ...melCacheInfo } = await this.computeFeatures(audio, sampleRate, { prefixSamples, _skipAudioValidation }));
     }
 
     // 2. Encode entire utterance
@@ -1329,6 +1329,9 @@ export class MelFeatureCache {
   _generateKey(audio) {
     const n = audio.length;
     if (n === 0) return '0_0';
+    const FULL_HASH_THRESHOLD = 1_000_000;
+    const EDGE_SAMPLE_COUNT = 1024;
+    const TARGET_SAMPLED_POINTS = 131072;
 
     // MurmurHash3-style 32-bit mix helper
     const mix32 = (h, v) => {
@@ -1355,8 +1358,25 @@ export class MelFeatureCache {
     // Seed with length so differently-sized arrays can never collide
     let h = n | 0;
 
-    // Hash all samples to minimize false cache hits across similar waveforms.
-    for (let i = 0; i < n; i++) h = mix32(h, audio[i]);
+    if (n <= FULL_HASH_THRESHOLD) {
+      // For the short/medium buffers this cache typically sees, full hashing
+      // remains the most robust collision guard.
+      for (let i = 0; i < n; i++) h = mix32(h, audio[i]);
+    } else {
+      // Very large buffers are sampled densely but deterministically to keep
+      // cache key generation from becoming a full-buffer O(n) bottleneck.
+      const edgeCount = Math.min(EDGE_SAMPLE_COUNT, Math.floor(n / 2));
+      for (let i = 0; i < edgeCount; i++) h = mix32(h, audio[i]);
+
+      const middleStart = edgeCount;
+      const middleEnd = n - edgeCount;
+      const middleLength = Math.max(0, middleEnd - middleStart);
+      const remainingBudget = Math.max(1, TARGET_SAMPLED_POINTS - (edgeCount * 2));
+      const stride = Math.max(1, Math.floor(middleLength / remainingBudget));
+      for (let i = middleStart; i < middleEnd; i += stride) h = mix32(h, audio[i]);
+
+      for (let i = Math.max(edgeCount, n - edgeCount); i < n; i++) h = mix32(h, audio[i]);
+    }
 
     return `${n}_${fmix32(h)}`;
   }

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -1322,7 +1322,7 @@ export class MelFeatureCache {
 
   /**
    * Generate a cache key from audio samples.
-   * Uses a fast hash based on length + sampled values.
+   * Uses full hashing for normal inputs and deterministic dense sampling for huge buffers.
    * @param {Float32Array} audio - Audio samples
    * @returns {string} Cache key
    */
@@ -1402,6 +1402,11 @@ export class MelFeatureCache {
 
     // Calculate size (Float32 = 4 bytes)
     const sizeMB = (features.length * 4) / (1024 * 1024);
+
+    // Skip caching entries that can never fit. Keep the existing cache warm.
+    if (sizeMB > this.maxCacheSizeMB) {
+      return { features, T, melBins, cached: false };
+    }
 
     // Evict old entries if needed
     while (this.currentSizeMB + sizeMB > this.maxCacheSizeMB && this.cache.size > 0) {

--- a/tests/decode_loop.test.mjs
+++ b/tests/decode_loop.test.mjs
@@ -78,6 +78,12 @@ function makeJoinerOutput(tokenLogits, durLogits) {
   };
 }
 
+function softmaxConfidence(logits, winnerIndex, temperature = 1) {
+  const scaledWinner = logits[winnerIndex] / temperature;
+  const sumExp = logits.reduce((sum, value) => sum + Math.exp((value / temperature) - scaledWinner), 0);
+  return 1 / sumExp;
+}
+
 describe('ParakeetModel decode loop', () => {
   it('emits multiple non-blank tokens on the same frame when step=0', async () => {
     const queue = [
@@ -164,6 +170,63 @@ describe('ParakeetModel decode loop', () => {
     expect(result.utterance_text).toBe('AA');
     expect(result.frameIndices.every((i) => i <= 2)).toBe(true);
     expect(joinerRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps token end timestamps to the final encoder frame when TDT overshoots', async () => {
+    const queue = [
+      makeJoinerOutput([0.1, 9.0, 0.2], [0.1, 0.2, 9.0]), // token=1, step=2
+      makeJoinerOutput([0.1, 0.2, 9.0], [0.1, 0.2, 9.0]), // token=2, step=2 at final frame
+    ];
+
+    let idx = 0;
+    const joinerRun = vi.fn().mockImplementation(async () => {
+      const out = queue[Math.min(idx, queue.length - 1)];
+      idx += 1;
+      return out;
+    });
+
+    const model = createModelForDecodeLoop({ tEnc: 3, joinerRun });
+    const result = await model.transcribe(new Float32Array(16000), 16000, {
+      returnTimestamps: true,
+      enableProfiling: false,
+    });
+
+    expect(result.tokens.map((token) => [token.start_time, token.end_time])).toEqual([
+      [0, 0.16],
+      [0.16, 0.24],
+    ]);
+  });
+
+  it('aggregates frame confidences once per encoder frame even with multiple token emissions', async () => {
+    const queue = [
+      { token: [0.1, 4.0, 0.2], step: [5.0, 1.0, 0.1] }, // token=1, step=0
+      { token: [0.1, 0.2, 8.0], step: [5.0, 1.0, 0.1] }, // token=2, step=0
+      { token: [9.0, 0.1, 0.2], step: [0.1, 9.0, 0.2] }, // blank, step=1 to exit
+    ].map(({ token, step }) => makeJoinerOutput(token, step));
+
+    let idx = 0;
+    const joinerRun = vi.fn().mockImplementation(async () => {
+      const out = queue[Math.min(idx, queue.length - 1)];
+      idx += 1;
+      return out;
+    });
+
+    const model = createModelForDecodeLoop({ tEnc: 1, joinerRun });
+    const result = await model.transcribe(new Float32Array(16000), 16000, {
+      returnConfidences: true,
+      enableProfiling: false,
+    });
+
+    const expectedFrameConfidence = (
+      softmaxConfidence([0.1, 4.0, 0.2], 1) +
+      softmaxConfidence([0.1, 0.2, 8.0], 2) +
+      softmaxConfidence([9.0, 0.1, 0.2], 0)
+    ) / 3;
+
+    expect(result.confidence_scores.token).toHaveLength(2);
+    expect(result.confidence_scores.frame).toHaveLength(1);
+    expect(result.confidence_scores.frame[0]).toBeCloseTo(expectedFrameConfidence, 4);
+    expect(result.confidence_scores.frame_avg).toBeCloseTo(expectedFrameConfidence, 4);
   });
 
   it('copies the correct transposed frame slice into reusable encoder buffer each step', async () => {

--- a/tests/incremental_cache_fix.test.mjs
+++ b/tests/incremental_cache_fix.test.mjs
@@ -35,8 +35,8 @@ describe('ParakeetModel Incremental Cache', () => {
   const mockJoinerSession = {
     run: async () => ({
       outputs: {
-        dims: [1, 1, 1, 3], // B, U, V, vocab (3) + dur (0)
-        data: new Float32Array([0.8, 0.1, 0.1]), // logits, index 0 (blank) is max
+        dims: [1, 1, 1, 6], // B, U, V, vocab (3) + dur (3)
+        data: new Float32Array([0.8, 0.1, 0.1, 9.0, 0.1, 0.1]), // blank token, step=0
       },
       output_states_1: { data: new Float32Array(10), dims: [1, 1, 10] },
       output_states_2: { data: new Float32Array(10), dims: [1, 1, 10] },
@@ -109,8 +109,8 @@ describe('ParakeetModel Incremental Cache', () => {
   it('should skip prefix frames only when cacheKey and prefixSeconds match', async () => {
     const joinerRun = vi.fn().mockResolvedValue({
       outputs: {
-        dims: [1, 1, 1, 3],
-        data: new Float32Array([0.8, 0.1, 0.1]), // blank
+        dims: [1, 1, 1, 6],
+        data: new Float32Array([0.8, 0.1, 0.1, 9.0, 0.1, 0.1]), // blank, step=0
       },
       output_states_1: { data: new Float32Array(10), dims: [1, 1, 10] },
       output_states_2: { data: new Float32Array(10), dims: [1, 1, 10] },

--- a/tests/long_audio_chunking.test.mjs
+++ b/tests/long_audio_chunking.test.mjs
@@ -139,4 +139,21 @@ describe('long-audio chunking helpers', () => {
       { text: 'bit.', start_time: 45.5, end_time: 45.9 },
     ]);
   });
+
+  it('rejects invalid sampleRate and timeOffset before scheduling windows', async () => {
+    const audio = new Float32Array(10 * 16000);
+    const model = {
+      transcribe: vi.fn(),
+    };
+
+    await expect(
+      transcribeLongAudioWithChunks(model, audio, 0, {}),
+    ).rejects.toThrow('positive finite number');
+
+    await expect(
+      transcribeLongAudioWithChunks(model, audio, 16000, { timeOffset: -1 }),
+    ).rejects.toThrow('finite non-negative number');
+
+    expect(model.transcribe).not.toHaveBeenCalled();
+  });
 });

--- a/tests/long_audio_chunking.test.mjs
+++ b/tests/long_audio_chunking.test.mjs
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ParakeetModel } from '../src/parakeet.js';
+import { transcribeLongAudioWithChunks } from '../src/long_audio.js';
+
+describe('long-audio chunking helpers', () => {
+  it('returns a simple text result when timestamps are not requested', async () => {
+    const audio = new Float32Array(10 * 16000);
+    const model = {
+      transcribe: vi.fn().mockResolvedValue({
+        utterance_text: 'hello world',
+        words: [],
+      }),
+    };
+
+    const result = await ParakeetModel.prototype.transcribeLongAudio.call(model, audio, 16000, {
+      timeOffset: 5,
+    });
+
+    expect(result).toEqual({ text: 'hello world' });
+    expect(model.transcribe).toHaveBeenCalledTimes(1);
+    expect(model.transcribe).toHaveBeenCalledWith(audio, 16000, expect.objectContaining({
+      returnTimestamps: false,
+      timeOffset: 5,
+    }));
+  });
+
+  it('returns per-word chunks when requested on a single-window transcription', async () => {
+    const audio = new Float32Array(12 * 16000);
+    const words = [
+      { text: 'Hello', start_time: 0, end_time: 0.4 },
+      { text: 'world.', start_time: 0.4, end_time: 0.9 },
+    ];
+    const model = {
+      transcribe: vi.fn().mockResolvedValue({
+        utterance_text: 'Hello world.',
+        words,
+      }),
+    };
+
+    const result = await transcribeLongAudioWithChunks(model, audio, 16000, {
+      returnTimestamps: 'word',
+      timeOffset: 1.25,
+    });
+
+    expect(result).toEqual({
+      text: 'Hello world.',
+      words,
+      chunks: [
+        { text: 'Hello', timestamp: [0, 0.4] },
+        { text: 'world.', timestamp: [0.4, 0.9] },
+      ],
+    });
+    expect(model.transcribe).toHaveBeenCalledWith(audio, 16000, expect.objectContaining({
+      returnTimestamps: true,
+      timeOffset: 1.25,
+    }));
+  });
+
+  it('uses sentence-aware window cursoring for long audio chunk assembly', async () => {
+    const sampleRate = 16000;
+    const audio = new Float32Array(45 * sampleRate);
+    const seenOffsets = [];
+    const scriptedOutputs = [
+      {
+        utterance_text: 'Hello world. Next sentence.',
+        words: [
+          { text: 'Hello', start_time: 5.0, end_time: 5.4 },
+          { text: 'world.', start_time: 5.4, end_time: 5.9 },
+          { text: 'Next', start_time: 24.2, end_time: 24.4 },
+          { text: 'sentence.', start_time: 24.4, end_time: 24.8 },
+        ],
+      },
+      {
+        utterance_text: 'Next sentence. Another one.',
+        words: [
+          { text: 'Next', start_time: 24.2, end_time: 24.4 },
+          { text: 'sentence.', start_time: 24.4, end_time: 24.8 },
+          { text: 'Another', start_time: 26.0, end_time: 26.3 },
+          { text: 'one.', start_time: 26.3, end_time: 26.7 },
+        ],
+      },
+      {
+        utterance_text: 'Another one. Final bit.',
+        words: [
+          { text: 'Another', start_time: 26.0, end_time: 26.3 },
+          { text: 'one.', start_time: 26.3, end_time: 26.7 },
+          { text: 'Final', start_time: 45.2, end_time: 45.5 },
+          { text: 'bit.', start_time: 45.5, end_time: 45.9 },
+        ],
+      },
+      {
+        utterance_text: 'Final bit.',
+        words: [
+          { text: 'Final', start_time: 45.2, end_time: 45.5 },
+          { text: 'bit.', start_time: 45.5, end_time: 45.9 },
+        ],
+      },
+    ];
+
+    const model = {
+      transcribe: vi.fn().mockImplementation(async (_windowAudio, _sampleRate, opts) => {
+        seenOffsets.push(opts.timeOffset);
+        return scriptedOutputs[seenOffsets.length - 1];
+      }),
+    };
+
+    const result = await ParakeetModel.prototype.transcribeLongAudio.call(model, audio, sampleRate, {
+      returnTimestamps: true,
+      chunkLengthS: 20,
+      timeOffset: 5,
+    });
+
+    expect(seenOffsets).toHaveLength(4);
+    expect(seenOffsets[0]).toBeCloseTo(5, 6);
+    expect(seenOffsets[1]).toBeCloseTo(24.2, 6);
+    expect(seenOffsets[2]).toBeCloseTo(26.0, 6);
+    expect(seenOffsets[3]).toBeCloseTo(45.2, 6);
+
+    expect(result.text).toBe('Hello world. Next sentence. Another one. Final bit.');
+    expect(result.chunks).toEqual([
+      { text: 'Hello world.', timestamp: [5.0, 5.9] },
+      { text: 'Next sentence.', timestamp: [24.2, 24.8] },
+      { text: 'Another one.', timestamp: [26.0, 26.7] },
+      { text: 'Final bit.', timestamp: [45.2, 45.9] },
+    ]);
+    expect(result.words).toEqual([
+      { text: 'Hello', start_time: 5.0, end_time: 5.4 },
+      { text: 'world.', start_time: 5.4, end_time: 5.9 },
+      { text: 'Next', start_time: 24.2, end_time: 24.4 },
+      { text: 'sentence.', start_time: 24.4, end_time: 24.8 },
+      { text: 'Another', start_time: 26.0, end_time: 26.3 },
+      { text: 'one.', start_time: 26.3, end_time: 26.7 },
+      { text: 'Final', start_time: 45.2, end_time: 45.5 },
+      { text: 'bit.', start_time: 45.5, end_time: 45.9 },
+    ]);
+  });
+});

--- a/tests/long_audio_chunking.test.mjs
+++ b/tests/long_audio_chunking.test.mjs
@@ -19,6 +19,7 @@ describe('long-audio chunking helpers', () => {
     expect(result).toEqual({ text: 'hello world' });
     expect(model.transcribe).toHaveBeenCalledTimes(1);
     expect(model.transcribe).toHaveBeenCalledWith(audio, 16000, expect.objectContaining({
+      _skipAudioValidation: true,
       returnTimestamps: false,
       timeOffset: 5,
     }));
@@ -51,6 +52,7 @@ describe('long-audio chunking helpers', () => {
       ],
     });
     expect(model.transcribe).toHaveBeenCalledWith(audio, 16000, expect.objectContaining({
+      _skipAudioValidation: true,
       returnTimestamps: true,
       timeOffset: 1.25,
     }));
@@ -115,6 +117,9 @@ describe('long-audio chunking helpers', () => {
     expect(seenOffsets[1]).toBeCloseTo(24.2, 6);
     expect(seenOffsets[2]).toBeCloseTo(26.0, 6);
     expect(seenOffsets[3]).toBeCloseTo(45.2, 6);
+    for (const call of model.transcribe.mock.calls) {
+      expect(call[2]._skipAudioValidation).toBe(true);
+    }
 
     expect(result.text).toBe('Hello world. Next sentence. Another one. Final bit.');
     expect(result.chunks).toEqual([

--- a/tests/mel_feature_cache.test.mjs
+++ b/tests/mel_feature_cache.test.mjs
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { MelFeatureCache } from '../src/parakeet.js';
+
+describe('MelFeatureCache', () => {
+  it('rejects invalid cache size limits', () => {
+    expect(() => new MelFeatureCache({ maxCacheSizeMB: 0 })).toThrow('positive number');
+    expect(() => new MelFeatureCache({ maxCacheSizeMB: Number.NaN })).toThrow('positive number');
+    expect(() => new MelFeatureCache({ maxCacheSizeMB: -1 })).toThrow('positive number');
+  });
+
+  it('hashes the full audio buffer when generating cache keys', () => {
+    const cache = new MelFeatureCache({ maxCacheSizeMB: 1 });
+    const first = new Float32Array(4096);
+    const second = new Float32Array(4096);
+
+    second[2048] = 0.25;
+
+    expect(cache._generateKey(first)).not.toBe(cache._generateKey(second));
+  });
+});

--- a/tests/mel_feature_cache.test.mjs
+++ b/tests/mel_feature_cache.test.mjs
@@ -17,4 +17,14 @@ describe('MelFeatureCache', () => {
 
     expect(cache._generateKey(first)).not.toBe(cache._generateKey(second));
   });
+
+  it('uses a deterministic large-buffer hash path for huge audio buffers', () => {
+    const cache = new MelFeatureCache({ maxCacheSizeMB: 1 });
+    const first = new Float32Array(1_100_000);
+    const second = new Float32Array(1_100_000);
+
+    second[1_099_999] = 0.25;
+
+    expect(cache._generateKey(first)).not.toBe(cache._generateKey(second));
+  });
 });

--- a/tests/mel_feature_cache.test.mjs
+++ b/tests/mel_feature_cache.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MelFeatureCache } from '../src/parakeet.js';
 
 describe('MelFeatureCache', () => {
@@ -26,5 +26,25 @@ describe('MelFeatureCache', () => {
     second[1_099_999] = 0.25;
 
     expect(cache._generateKey(first)).not.toBe(cache._generateKey(second));
+  });
+
+  it('does not cache entries that exceed the cache size by themselves', async () => {
+    const cache = new MelFeatureCache({ maxCacheSizeMB: 0.001 });
+    const audio = new Float32Array(1600);
+    const model = {
+      computeFeatures: vi.fn().mockResolvedValue({
+        features: new Float32Array(1024),
+        T: 8,
+        melBins: 128,
+      }),
+    };
+
+    const first = await cache.getFeatures(model, audio);
+    const second = await cache.getFeatures(model, audio);
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(false);
+    expect(model.computeFeatures).toHaveBeenCalledTimes(2);
+    expect(cache.getStats().entries).toBe(0);
   });
 });

--- a/tests/transcribe_perf.test.mjs
+++ b/tests/transcribe_perf.test.mjs
@@ -524,6 +524,91 @@ describe('ParakeetModel.transcribe tensor disposal', () => {
     expect(state2.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('should dispose the active decoder state when decoder output validation fails', async () => {
+    const logits = {
+      dims: [1, 1, 1, 3],
+      data: new Float32Array([0.1, 9.0, 0.2]),
+      dispose: vi.fn(),
+    };
+    const returnedState1 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+    const returnedState2 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+    const activeState1 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+    const activeState2 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a', 'b'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a', 'b'],
+      },
+      encoderSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 64, 1], data: new Float32Array(64), dispose: vi.fn() },
+        }),
+      },
+      joinerSession: {
+        run: vi.fn()
+          .mockResolvedValueOnce({
+            outputs: {
+              dims: [1, 1, 1, 4],
+              data: new Float32Array([0.1, 9.0, 0.2, 0.9]),
+              dispose: vi.fn(),
+            },
+            output_states_1: activeState1,
+            output_states_2: activeState2,
+          })
+          .mockResolvedValueOnce({
+            outputs: logits,
+            output_states_1: returnedState1,
+            output_states_2: returnedState2,
+          }),
+      },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(256), length: 2 }),
+        nMels: 128,
+      },
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      model.transcribe(new Float32Array(32000), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('missing required TDT duration logits');
+
+    expect(logits.dispose).toHaveBeenCalledTimes(1);
+    expect(returnedState1.dispose).toHaveBeenCalledTimes(1);
+    expect(returnedState2.dispose).toHaveBeenCalledTimes(1);
+    expect(activeState1.dispose).toHaveBeenCalledTimes(1);
+    expect(activeState2.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it('should dispose decoder outputs when logits are smaller than the tokenizer vocab', async () => {
     const logits = {
       dims: [1, 1, 1, 2],

--- a/tests/transcribe_perf.test.mjs
+++ b/tests/transcribe_perf.test.mjs
@@ -105,7 +105,7 @@ describe('ParakeetModel.transcribe tensor disposal', () => {
 
     // Joiner output: logits + states all with .dispose()
     const makeJoinerOutput = () => {
-      const logits = { dims: [1, 1, 1, 3], data: new Float32Array([0.8, 0.1, 0.1]), dispose: vi.fn() };
+      const logits = { dims: [1, 1, 1, 6], data: new Float32Array([0.8, 0.1, 0.1, 9.0, 0.1, 0.1]), dispose: vi.fn() };
       const s1 = { dims: [2, 1, 640], data: new Float32Array(1280), dispose: vi.fn() };
       const s2 = { dims: [2, 1, 640], data: new Float32Array(1280), dispose: vi.fn() };
       return { outputs: logits, output_states_1: s1, output_states_2: s2 };
@@ -242,5 +242,348 @@ describe('ParakeetModel.transcribe tensor disposal', () => {
     expect(joinerOutputs[1].output_states_1.dispose).toHaveBeenCalledTimes(1);
     expect(joinerOutputs[1].output_states_2.dispose).toHaveBeenCalledTimes(1);
     expect(stateDisposes.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('should dispose auxiliary decoder outputs returned by the joiner session', async () => {
+    class SpyTensor {
+      constructor(type, data, dims) {
+        this.type = type;
+        this.data = data;
+        this.dims = dims;
+      }
+      dispose() {}
+    }
+
+    const auxiliaryOutput = {
+      dims: [1, 4],
+      data: new Float32Array([1, 2, 3, 4]),
+      dispose: vi.fn(),
+    };
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a'],
+      },
+      encoderSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 64, 1], data: new Float32Array(64), dispose: vi.fn() },
+        }),
+      },
+      joinerSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 1, 1, 4], data: new Float32Array([9, 0.1, 8, 0.1]), dispose: vi.fn() },
+          output_states_1: { dims: [2, 1, 640], data: new Float32Array(1280), dispose: vi.fn() },
+          output_states_2: { dims: [2, 1, 640], data: new Float32Array(1280), dispose: vi.fn() },
+          decoder_aux: auxiliaryOutput,
+        }),
+      },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(128), length: 1 }),
+        nMels: 128,
+      },
+      ort: { Tensor: SpyTensor },
+      nMels: 128,
+    });
+
+    await model.transcribe(new Float32Array(16000), 16000, { enableProfiling: false });
+
+    expect(auxiliaryOutput.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject non-finite timeOffset values before decoding', async () => {
+    const validationModel = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a'],
+      },
+      encoderSession: { run: vi.fn() },
+      joinerSession: { run: vi.fn() },
+      preprocessor: { process: vi.fn(), nMels: 128 },
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      validationModel.transcribe(new Float32Array(16000), 16000, { timeOffset: Number.NaN, enableProfiling: false }),
+    ).rejects.toThrow('finite number');
+
+    await expect(
+      validationModel.transcribe(new Float32Array(16000), 16000, { timeOffset: Number.POSITIVE_INFINITY, enableProfiling: false }),
+    ).rejects.toThrow('finite number');
+  });
+
+  it('should reject non-finite audio samples before preprocessing', async () => {
+    const preprocessor = {
+      process: vi.fn(),
+      nMels: 128,
+    };
+    const validationModel = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a'],
+      },
+      encoderSession: { run: vi.fn() },
+      joinerSession: { run: vi.fn() },
+      preprocessor,
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      validationModel.transcribe(new Float32Array([0.1, Number.NaN, 0.2]), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('finite audio samples');
+
+    expect(preprocessor.process).not.toHaveBeenCalled();
+  });
+
+  it('should dispose encoder input tensors when encoder execution fails', async () => {
+    const disposeCalls = [];
+
+    class SpyTensor {
+      constructor(type, data, dims) {
+        this.type = type;
+        this.data = data;
+        this.dims = dims;
+      }
+      dispose() {
+        disposeCalls.push(this.dims.join('x'));
+      }
+    }
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a'],
+      },
+      encoderSession: {
+        run: vi.fn().mockRejectedValue(new Error('encoder boom')),
+      },
+      joinerSession: { run: vi.fn() },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(128), length: 1 }),
+        nMels: 128,
+      },
+      ort: { Tensor: SpyTensor },
+      nMels: 128,
+    });
+
+    await expect(
+      model.transcribe(new Float32Array(16000), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('encoder boom');
+
+    expect(disposeCalls).toEqual(expect.arrayContaining(['1x128x1', '1']));
+  });
+
+  it('should dispose malformed decoder outputs before throwing', async () => {
+    const logits = {
+      dims: [1, 1, 1, 2],
+      data: new Float32Array([0.1, 9.0]),
+      dispose: vi.fn(),
+    };
+    const state1 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a', 'b'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a', 'b'],
+      },
+      encoderSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 64, 1], data: new Float32Array(64), dispose: vi.fn() },
+        }),
+      },
+      joinerSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: logits,
+          output_states_1: state1,
+        }),
+      },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(128), length: 1 }),
+        nMels: 128,
+      },
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      model.transcribe(new Float32Array(16000), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('decoder output did not include both decoder state tensors');
+
+    expect(logits.dispose).toHaveBeenCalledTimes(1);
+    expect(state1.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject decoder outputs that omit TDT duration logits', async () => {
+    const logits = {
+      dims: [1, 1, 1, 3],
+      data: new Float32Array([0.1, 9.0, 0.2]),
+      dispose: vi.fn(),
+    };
+    const state1 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+    const state2 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a', 'b'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a', 'b'],
+      },
+      encoderSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 64, 1], data: new Float32Array(64), dispose: vi.fn() },
+        }),
+      },
+      joinerSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: logits,
+          output_states_1: state1,
+          output_states_2: state2,
+        }),
+      },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(128), length: 1 }),
+        nMels: 128,
+      },
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      model.transcribe(new Float32Array(16000), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('missing required TDT duration logits');
+
+    expect(logits.dispose).toHaveBeenCalledTimes(1);
+    expect(state1.dispose).toHaveBeenCalledTimes(1);
+    expect(state2.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dispose decoder outputs when logits are smaller than the tokenizer vocab', async () => {
+    const logits = {
+      dims: [1, 1, 1, 2],
+      data: new Float32Array([9.0, 0.1]),
+      dispose: vi.fn(),
+    };
+    const state1 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+    const state2 = {
+      dims: [2, 1, 640],
+      data: new Float32Array(1280),
+      dispose: vi.fn(),
+    };
+
+    const model = new ParakeetModel({
+      tokenizer: {
+        blankId: 0,
+        id2token: ['<blank>', 'a', 'b'],
+        blankToken: '<blank>',
+        decode: () => '',
+        sanitizedTokens: ['<blank>', 'a', 'b'],
+      },
+      encoderSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: { dims: [1, 64, 1], data: new Float32Array(64), dispose: vi.fn() },
+        }),
+      },
+      joinerSession: {
+        run: vi.fn().mockResolvedValue({
+          outputs: logits,
+          output_states_1: state1,
+          output_states_2: state2,
+        }),
+      },
+      preprocessor: {
+        process: vi.fn().mockResolvedValue({ features: new Float32Array(128), length: 1 }),
+        nMels: 128,
+      },
+      ort: {
+        Tensor: class {
+          constructor(type, data, dims) {
+            this.type = type;
+            this.data = data;
+            this.dims = dims;
+          }
+          dispose() {}
+        },
+      },
+      nMels: 128,
+    });
+
+    await expect(
+      model.transcribe(new Float32Array(16000), 16000, { enableProfiling: false }),
+    ).rejects.toThrow('too small');
+
+    expect(logits.dispose).toHaveBeenCalledTimes(1);
+    expect(state1.dispose).toHaveBeenCalledTimes(1);
+    expect(state2.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,8 @@ import type { GetParakeetModelOptions } from './hub';
 export type {
   TranscribeResult,
   TranscribeOptions,
+  LongAudioTranscribeOptions,
+  LongAudioTranscribeResult,
   FromUrlsConfig,
 } from './parakeet';
 

--- a/types/parakeet.d.ts
+++ b/types/parakeet.d.ts
@@ -109,6 +109,22 @@ export interface TranscribeResult {
   tdtSteps?: number[];
 }
 
+export interface LongAudioChunk {
+  text: string;
+  timestamp: [number, number];
+}
+
+export interface LongAudioTranscribeOptions extends Omit<TranscribeOptions, 'returnTimestamps'> {
+  returnTimestamps?: boolean | 'word';
+  chunkLengthS?: number;
+}
+
+export interface LongAudioTranscribeResult {
+  text: string;
+  words?: TranscribeWord[];
+  chunks?: LongAudioChunk[];
+}
+
 export interface FromUrlsConfig {
   encoderUrl: string;
   decoderUrl: string;
@@ -155,6 +171,7 @@ export class ParakeetModel {
     maxTokensPerStep: number;
   };
   transcribe(audio: Float32Array | null, sampleRate?: number, opts?: TranscribeOptions): Promise<TranscribeResult>;
+  transcribeLongAudio(audio: Float32Array | Float64Array, sampleRate?: number, opts?: LongAudioTranscribeOptions): Promise<LongAudioTranscribeResult>;
   createStreamingTranscriber(opts?: StreamingTranscriberOptions): StatefulStreamingTranscriber;
   endProfiling(): Record<string, { gpu_us: number; cpu_us: number; total_us: number }> | null;
 }


### PR DESCRIPTION
Summary
- add sentence-aware transcribeLongAudio() retranscription with chunk output support
- harden decoder validation, cache hashing, and tensor cleanup paths
- document the new API and add regression coverage for long-audio, timestamps, confidences, and error paths

Validation
- npm test