### PR TITLE
Optimize FrameAlignedMerger._findAnchors nested loop with Map lookup

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -1618,14 +1618,25 @@ export class FrameAlignedMerger {
   _findAnchors(overlapTokens) {
     const anchors = [];
 
+    // Pre-group pending tokens by ID for O(1) lookup
+    const pendingById = new Map();
+    for (const pendTok of this.pendingTokens) {
+      const list = pendingById.get(pendTok.id);
+      if (list) {
+        list.push(pendTok);
+      } else {
+        pendingById.set(pendTok.id, [pendTok]);
+      }
+    }
+
     for (const newTok of overlapTokens) {
-      for (const pendTok of this.pendingTokens) {
-        if (
-          newTok.id === pendTok.id &&
-          Math.abs(newTok.absTime - pendTok.absTime) < this.timeTolerance
-        ) {
-          anchors.push(newTok);
-          break;
+      const candidates = pendingById.get(newTok.id);
+      if (candidates) {
+        for (const pendTok of candidates) {
+          if (Math.abs(newTok.absTime - pendTok.absTime) < this.timeTolerance) {
+            anchors.push(newTok);
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
What: The optimization replaces the nested loop O(N * M) token ID match check in `FrameAlignedMerger._findAnchors` with a `Map`-based lookup to pre-group pending tokens by ID, reducing time complexity to O(N + M).
Why: The original implementation utilized a double `for` loop to match `overlapTokens` with `pendingTokens`, which became slow for larger context sizes. Pre-grouping pending tokens dynamically per chunk significantly speeds up the overlap processing, which is crucial for realtime transcription alignment.
**Measured Improvement:** In a micro-benchmark using 1000 pending tokens and 100 overlap tokens repeated 1000 times, the duration decreased from ~430 ms to ~61 ms, exhibiting an approximate ~7x speedup for this specific method execution.

---
*PR created automatically by Jules for task [17754639683340904162](https://jules.google.com/task/17754639683340904162) started by @ysdede*