### PR TITLE
Remove unused `isFullWasm` variable in parakeet.js

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -160,7 +160,6 @@ export class ParakeetModel {
 
     // 2. Configure session options for better performance
     const graphCaptureEnabled = !!enableGraphCapture && backend === 'webgpu-strict';
-    const isFullWasm = backend === 'wasm';
 
     const baseSessionOptions = {
       executionProviders: [],


### PR DESCRIPTION
🎯 **What:** Removed the unused `isFullWasm` variable assignment from `src/parakeet.js`.
💡 **Why:** The variable was assigned but never used, cluttering the code and making it slightly harder to maintain. Removing it improves code health without altering behavior.
✅ **Verification:** Ran a syntax check using `node --check src/parakeet.js` to ensure the changes did not introduce any syntax errors. Searched the codebase to guarantee that the variable is not referenced anywhere else.
✨ **Result:** A cleaner and slightly more readable `parakeet.js` file with dead code removed.

---
*PR created automatically by Jules for task [23240570675393498](https://jules.google.com/task/23240570675393498) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Simplify parakeet.js by removing an unused backend-related variable assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code cleanup and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->