### PR TITLE
Remove unused `wasmPaths` parameter from initOrt

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -13,7 +13,7 @@
  * @param {number} [opts.numThreads] Number of WASM threads to use when SharedArrayBuffer is available.
  * @returns {Promise<typeof import('onnxruntime-web').default>}
  */
-export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
+export async function initOrt({ backend = 'webgpu', numThreads } = {}) {
   // Dynamic import to handle Vite bundling issues
   let ort;
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `wasmPaths` destructured parameter from the `initOrt` function signature in `src/backend.js`.
💡 **Why:** The parameter was destructured but never actually used within the function body (the function correctly accesses `ort.env.wasm.wasmPaths` instead). Removing it improves code health and readability by eliminating dead parameter bindings without affecting logic.
✅ **Verification:** Verified that the modification is syntax-error-free by running `node --check src/backend.js`, `src/parakeet.js`, `tests/models.test.mjs`, and `tests/index.test.mjs`.
✨ **Result:** A cleaner, more maintainable `initOrt` function signature.

---
*PR created automatically by Jules for task [6410171491687616532](https://jules.google.com/task/6410171491687616532) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Remove the unused wasmPaths option from the initOrt function parameters to improve code clarity.