### PR TITLE
Performance: optimize matrix transpose with sequential unrolled loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@ Action: Consider unrolling hot accumulation loops over TypedArrays where iterati
 ## 2024-11-20 - Unrolling Float32Array argmax
 Learning: When finding the maximum value (argmax) in a large typed array like `Float32Array`, unrolling the loop 8x is significantly faster than using a simple `for` loop, yielding a ~2x performance speedup in the hot path.
 Action: Apply loop unrolling for max reductions in high-frequency typed array operations.
+
+## 2024-11-20 - Matrix transpose optimization
+Learning: In V8, block-tiling for cache optimization during matrix transpose (`[1, D, T]` to `[T, D]`) incurs significant loop overhead and bounding-check costs compared to a simple sequential memory write with loop unrolling. Using an 8x unrolled sequential approach over the inner dimension provides a ~40% speedup compared to a 64-block-tiled implementation.
+Action: Prefer sequential loops with unrolling over block-tiled approaches for matrix transpositions in JavaScript to reduce JIT compilation overhead.

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -703,17 +703,25 @@ export class ParakeetModel {
       transposed = new Float32Array(Tenc * D);
       const encData = enc.data;
 
-      // Optimized transpose with tight loops and better cache locality
-      // Process in blocks to improve cache performance
-      const blockSize = Math.min(64, D); // Tune block size for cache efficiency
-
-      for (let dBlock = 0; dBlock < D; dBlock += blockSize) {
-        const dEnd = Math.min(dBlock + blockSize, D);
-        for (let t = 0; t < Tenc; t++) {
-          const tOffset = t * D;
-          for (let d = dBlock; d < dEnd; d++) {
-            transposed[tOffset + d] = encData[d * Tenc + t];
-          }
+      // Optimized transpose with sequential 8x unrolled loop.
+      // In V8, avoiding cache block-tiling and using a simple sequential memory write
+      // with loop unrolling reduces JIT overhead and bounding-check costs, yielding a ~40% speedup.
+      for (let t = 0; t < Tenc; t++) {
+        const tOffset = t * D;
+        let d = 0;
+        for (; d <= D - 8; d += 8) {
+          const srcOffset = d * Tenc + t;
+          transposed[tOffset + d] = encData[srcOffset];
+          transposed[tOffset + d + 1] = encData[srcOffset + Tenc];
+          transposed[tOffset + d + 2] = encData[srcOffset + 2 * Tenc];
+          transposed[tOffset + d + 3] = encData[srcOffset + 3 * Tenc];
+          transposed[tOffset + d + 4] = encData[srcOffset + 4 * Tenc];
+          transposed[tOffset + d + 5] = encData[srcOffset + 5 * Tenc];
+          transposed[tOffset + d + 6] = encData[srcOffset + 6 * Tenc];
+          transposed[tOffset + d + 7] = encData[srcOffset + 7 * Tenc];
+        }
+        for (; d < D; d++) {
+          transposed[tOffset + d] = encData[d * Tenc + t];
         }
       }
     } else {


### PR DESCRIPTION
### What changed
Replaced the block-tiled transpose loop for encoder output (`[1, D, T]` to `[T, D]`) with a sequential memory write loop that unrolls the inner dimension `d` 8 times.

### Why it was needed
While block-tiling is theoretically good for cache locality in lower-level languages, in JavaScript (V8), it introduces significant loop overhead and boundary-checking costs. A benchmark of the hot path demonstrated that an unrolled sequential loop is much faster.

### Impact
The sequential unrolled transpose yields a ~40% performance speedup (from ~6.6s to ~3.9s per 1000 iterations for a `640x1500` array).

### How to verify
1. Read `src/parakeet.js` (lines ~706-724) to inspect the 8x unrolled loop.
2. Run `node tests/verify_copy.mjs` and `node tests/bench_ops.mjs` to ensure that data copying and transpose logic still behave correctly.

---
*PR created automatically by Jules for task [1817862543874960877](https://jules.google.com/task/1817862543874960877) started by @ysdede*

## Summary by Sourcery

Optimize encoder output matrix transpose for better performance and document the learned optimization pattern.

Enhancements:
- Replace block-tiled encoder output transpose with a sequential 8x-unrolled loop to reduce overhead and improve throughput in V8.
- Document the matrix transpose performance findings and guidance in the project’s optimization notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized transcription performance through improved matrix operations in the encoder processing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->