### PR TITLE
Remove dead commented-out ort._selectedBackend assignment

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -98,10 +98,6 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
     }
   }
 
-  // Store the final backend choice for use in model selection
-  // Store the final backend choice for use in model selection
-  // ort._selectedBackend = backend; // Removed: ort object is not extensible in newer versions
-
   // Expose ort globally so other modules (like SileroVAD) can use the same configured instance
   if (typeof globalThis !== 'undefined') {
     globalThis.ort = ort;


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code (`ort._selectedBackend = backend;`) and its associated duplicate comments in `src/backend.js`.
💡 **Why:** As the inline comment indicated, the `ort` object is no longer extensible in newer versions of ONNX Runtime Web. Leaving this dead code and duplicated comments clutters the file and provides no value. Removing it improves readability and general code health.
✅ **Verification:** Verified syntax correctness by running `node --check src/backend.js`. As this patch only removes comments, it introduces zero risk of functional changes or regressions.
✨ **Result:** A cleaner `src/backend.js` with redundant comments removed, improving maintainability.

---
*PR created automatically by Jules for task [16569843542320907806](https://jules.google.com/task/16569843542320907806) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Remove dead commented-out assignment and duplicate comments related to backend selection from src/backend.js to improve readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused commented-out code to improve code cleanliness and maintainability. No functional changes or user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->