### PR TITLE
chore: update comment to prevent issue tracker false positive

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -891,7 +891,7 @@ export class ParakeetModel {
       _logitsTensor?.dispose?.();
 
       if (maxId !== this.blankId) {
-        // CRITICAL FIX: Only update decoder state on non-blank token emission
+        // CRITICAL: Only update decoder state on non-blank token emission
         // This matches the Python reference in onnx-asr/src/onnx_asr/asr.py line 212
         this._disposeDecoderState(decoderState, newState); // free old state tensors
         decoderState = newState;


### PR DESCRIPTION
Changed 'CRITICAL FIX:' to 'CRITICAL:' in `src/parakeet.js` to stop automated issue trackers from flagging an already-implemented bugfix note as an actionable TODO.

---
*PR created automatically by Jules for task [16196370544106810255](https://jules.google.com/task/16196370544106810255) started by @ysdede*

## Summary by Sourcery

Chores:
- Adjust an inline comment label from 'CRITICAL FIX' to 'CRITICAL' in the Parakeet model to prevent false-positive TODO detection by tooling.