### PR TITLE
Remove duplicate backend choice comment in src/backend.js

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -99,7 +99,6 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
   }
 
   // Store the final backend choice for use in model selection
-  // Store the final backend choice for use in model selection
   // ort._selectedBackend = backend; // Removed: ort object is not extensible in newer versions
 
   // Expose ort globally so other modules (like SileroVAD) can use the same configured instance


### PR DESCRIPTION
🎯 **What:** Removed a duplicated comment `// Store the final backend choice for use in model selection` in `src/backend.js`.
💡 **Why:** It was an obvious copy-paste error repeating the exact same comment text on consecutive lines. Removing the duplicate cleans up the code and improves readability without affecting functionality.
✅ **Verification:** Validated syntax with `node --check src/backend.js` to ensure the codebase remains structurally sound. No functional changes were made.
✨ **Result:** Improved maintainability and reduced minor clutter in the code.

---
*PR created automatically by Jules for task [6527039693618645185](https://jules.google.com/task/6527039693618645185) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Clean up src/backend.js by deleting a redundant repeated comment without changing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant comment line for code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->