### PR TITLE
Code Health: Remove dead `encTensor` comment in hot path

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -792,7 +792,6 @@ export class ParakeetModel {
       const frameStart = t * D;
       // Benchmark-driven hot path: keep this as set(subarray) (see tests/bench_ops.mjs, tests/verify_copy.mjs).
       this._encoderFrameBuffer.set(transposed.subarray(frameStart, frameStart + D));
-      // const encTensor = new this.ort.Tensor('float32', this._encoderFrameBuffer, [1, D, 1]);
 
       const prevTok = ids.length ? ids[ids.length - 1] : this.blankId;
       const { tokenLogits, step, newState, _logitsTensor } = await this._runCombinedStep(this._encoderFrameTensor, prevTok, decoderState);


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `encTensor` declaration in the `transcribe` method within `src/parakeet.js`.

💡 **Why:** This line was dead code. Removing it improves code readability and removes unnecessary clutter from the hot path without altering any functionality.

✅ **Verification:** 
- Checked syntax using `node --check src/parakeet.js`.
- Ran the specific ops tests via `node tests/verify_copy.mjs`, ensuring the core structure passes successfully with no regressions.
- Received code review confirmation that this purely cosmetic change carries zero risk of side effects.

✨ **Result:** A cleaner, more maintainable hot path in the transcription loop.

---
*PR created automatically by Jules for task [17109635455976352179](https://jules.google.com/task/17109635455976352179) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Remove an unused commented-out encoder tensor declaration from the transcribe hot path to reduce clutter without changing behavior.