### PR TITLE
Fix ORT-web graph capture bug

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -170,8 +170,8 @@ export class ParakeetModel {
       enableCpuMemArena: true,
       enableMemPattern: true,
       enableProfiling,
-      enableGraphCapture: graphCaptureEnabled,
       logSeverityLevel: verbose ? 0 : 2,
+      ...(graphCaptureEnabled && { enableGraphCapture: true }),
     };
 
     // Set execution provider based on backend
@@ -231,7 +231,7 @@ export class ParakeetModel {
         const msg = (e.message || '') + '';
         if (opts.enableGraphCapture && msg.includes('graph capture')) {
           console.warn('[Parakeet] Graph-capture unsupported for this model/backend; retrying without it');
-          const retryOpts = { ...opts, enableGraphCapture: false };
+          const { enableGraphCapture, ...retryOpts } = opts;
           return await ort.InferenceSession.create(url, retryOpts);
         }
         throw e;
@@ -251,7 +251,6 @@ export class ParakeetModel {
         backend: 'wasm',
         wasmPaths,
         enableProfiling,
-        enableGraphCapture: false,
         numThreads: cpuThreads
       });
       console.log(`[Parakeet.js] ONNX preprocessor session created (${detectedMels} mel bins)`);

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -55,7 +55,8 @@ export class OnnxPreprocessor {
           const msg = (e.message || '') + '';
           if (sessOpts.enableGraphCapture && msg.includes('graph capture')) {
             console.warn('[Preprocessor] Graph capture unsupported, retrying without it');
-            return await this.ort.InferenceSession.create(this.modelUrl, { ...sessOpts, enableGraphCapture: false });
+            const { enableGraphCapture, ...retryOpts } = sessOpts;
+            return await this.ort.InferenceSession.create(this.modelUrl, retryOpts);
           }
           throw e;
         }


### PR DESCRIPTION
Refactored session options in `src/preprocessor.js` and `src/parakeet.js` to avoid explicitly passing `enableGraphCapture: false`.

Due to a bug in `ORT-web`, passing the flag as false can still inadvertently trigger the graph-capture execution path, which causes external buffer requirements and fails. This patch ensures the property is only included when explicitly `true` and that it is fully removed from retry options when the initial capture attempt fails.

---
*PR created automatically by Jules for task [16420744521506251835](https://jules.google.com/task/16420744521506251835) started by @ysdede*

## Summary by Sourcery

Adjust ONNX Runtime Web session options to avoid incorrectly triggering graph capture and to cleanly remove the option on retry when unsupported.

Bug Fixes:
- Prevent ORT-web sessions from inadvertently taking the graph-capture code path when graph capture is disabled by ensuring the option is only set when true and removed entirely on retry.

Enhancements:
- Refine Parakeet and preprocessor session option construction to rely on conditional inclusion of the graph capture flag instead of explicitly setting it to false.