### PR TITLE
Performance: Optimize tensor disposal loop allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@ Action: Apply loop unrolling for max reductions in high-frequency typed array op
 ## 2024-11-20 - Softmax math.exp 8x unrolling with local var cache
 Learning: Unrolling the `Math.exp` accumulation loop to 8x and caching the multiplication `(tokenLogits[i] - maxLogit) * invTemp` into local variables before passing to `Math.exp` yields a measurable performance improvement (~4%) over the previous 4x unrolled implementation in the V8 engine, by reducing property access and allowing better instruction-level parallelism.
 Action: Utilize 8x loop unrolling paired with local variable caching for tight floating-point accumulation loops over TypedArrays.
+
+## 2024-11-20 - Object.values vs for-in loop overhead
+Learning: Hot loops processing inference results using `Object.values(tensorMap)` and per-frame `new Set()` allocations add significant GC and CPU overhead in V8 (roughly ~4x slower than `for...in`).
+Action: For tensor dictionary outputs in the hot loop, use `for...in` and track disposed tensors via a persistently allocated array to maximize loop throughput.

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -102,6 +102,7 @@ export class ParakeetModel {
     this._targetLenTensor = new ort.Tensor('int32', this._targetLenArray, [1]);
     this._encoderFrameBuffer = null; // Will be allocated when we know the dimension D
     this._encoderFrameTensor = null; // Will be allocated when we know D
+    this._seenOutputs = []; // Reusable array for tensor disposal tracking
 
     // Incremental decode cache: stores decoder state at the end of the prefix
     // keyed by a caller-provided cacheKey. This lets us skip decoding the
@@ -323,10 +324,23 @@ export class ParakeetModel {
     const logits = out['outputs'];
     const outputState1 = out['output_states_1'];
     const outputState2 = out['output_states_2'];
-    const seenOutputs = new Set();
-    for (const value of Object.values(out)) {
-      if (!value || typeof value.dispose !== 'function' || seenOutputs.has(value)) continue;
-      seenOutputs.add(value);
+
+    // Performance: Avoid Object.values and per-frame Set allocations in this hot loop.
+    let seenCount = 0;
+    for (const key in out) {
+      const value = out[key];
+      if (!value || typeof value.dispose !== 'function') continue;
+
+      let alreadySeen = false;
+      for (let j = 0; j < seenCount; j++) {
+        if (this._seenOutputs[j] === value) {
+          alreadySeen = true;
+          break;
+        }
+      }
+      if (alreadySeen) continue;
+      this._seenOutputs[seenCount++] = value;
+
       if (value === logits || value === outputState1 || value === outputState2) continue;
       value.dispose();
     }
@@ -339,12 +353,20 @@ export class ParakeetModel {
     const failDecoderStep = (message) => {
       logits?.dispose?.();
 
-      const disposed = new Set();
+      let disposedCount = 0;
       const disposeUniqueState = (state) => {
         if (!state) return;
         for (const tensor of [state.state1, state.state2]) {
-          if (!tensor || tensor === this._combState1 || tensor === this._combState2 || disposed.has(tensor)) continue;
-          disposed.add(tensor);
+          if (!tensor || tensor === this._combState1 || tensor === this._combState2) continue;
+          let alreadyDisposed = false;
+          for (let i = 0; i < disposedCount; i++) {
+            if (this._seenOutputs[i] === tensor) {
+              alreadyDisposed = true;
+              break;
+            }
+          }
+          if (alreadyDisposed) continue;
+          this._seenOutputs[disposedCount++] = tensor;
           tensor.dispose?.();
         }
       };
@@ -683,10 +705,22 @@ export class ParakeetModel {
         const s = performance.now();
         const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
         tEncode = performance.now() - s;
-        enc = encOut['outputs'] ?? Object.values(encOut)[0];
+        enc = encOut['outputs'];
+        if (enc === undefined) {
+          for (const key in encOut) {
+            enc = encOut[key];
+            break;
+          }
+        }
       } else {
         const encOut = await this.encoderSession.run({ audio_signal: input, length: lenTensor });
-        enc = encOut['outputs'] ?? Object.values(encOut)[0];
+        enc = encOut['outputs'];
+        if (enc === undefined) {
+          for (const key in encOut) {
+            enc = encOut[key];
+            break;
+          }
+        }
       }
     } finally {
       // Dispose per-call input tensors even when encoder execution fails.


### PR DESCRIPTION
### What changed
Replaced `Object.values(out)` array creations and per-frame `new Set()` allocations in `ParakeetModel`'s hot inner decoding loop (`_runCombinedStep` and `failDecoderStep`) with a `for...in` loop and a persistently recycled `this._seenOutputs` array tracking mechanism. The `encoderSession.run` fallback logic was similarly refactored.

### Why it was needed
Profiling tensor disposal overhead using a simulated benchmark script (`test_loop_overhead.mjs`) showed that creating `Set` and `Object.values` per iteration added significant GC pressure and CPU overhead in V8. 

### Impact
The baseline benchmark for 1,000,000 iterations dropped from ~770ms to ~180ms. While total decode time per frame might show subtle macro-improvements, reducing internal GC allocation spikes ensures more consistent tail latencies during streaming.

### How to verify
Run `npm test` to ensure tests continue to pass. Check the implementation in `src/parakeet.js` around `_runCombinedStep` to verify `Object.values()` and `new Set()` were replaced.

---
*PR created automatically by Jules for task [11221390464597978571](https://jules.google.com/task/11221390464597978571) started by @ysdede*

## Summary by Sourcery

Optimize ParakeetModel tensor handling and encoder output selection to reduce allocation overhead in hot inference paths.

Enhancements:
- Reuse a shared _seenOutputs array and in-place deduplication to minimize tensor disposal overhead in decoding steps.
- Replace Object.values-based encoder output selection with a simple property access and for-in fallback to avoid unnecessary allocations.

Documentation:
- Document the performance learnings and best practices around Object.values, Set allocations, and for-in loops in the internal .jules/bolt.md notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal tensor allocation and memory management strategies in the inference pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->