### PR TITLE
Performance: Argmax loop unrolling direct access

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@ Action: Apply loop unrolling for max reductions in high-frequency typed array op
 ## 2024-11-20 - Softmax math.exp 8x unrolling with local var cache
 Learning: Unrolling the `Math.exp` accumulation loop to 8x and caching the multiplication `(tokenLogits[i] - maxLogit) * invTemp` into local variables before passing to `Math.exp` yields a measurable performance improvement (~4%) over the previous 4x unrolled implementation in the V8 engine, by reducing property access and allowing better instruction-level parallelism.
 Action: Utilize 8x loop unrolling paired with local variable caching for tight floating-point accumulation loops over TypedArrays.
+
+## 2024-11-20 - Unrolled Float32Array argmax uses direct access
+Learning: Unlike heavy accumulation loops where caching variables helps, pure branch loops (like argmax) over TypedArrays in V8 are >10% faster using direct array access (e.g., `if (arr[i] > max)`) rather than reading values into local variables first, as direct access avoids forced assignment overhead on every iteration.
+Action: For pure branch loops (no math/accumulation) over TypedArrays, unroll and use direct array access rather than caching elements to local variables.

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -808,26 +808,18 @@ export class ParakeetModel {
       for (; i < tLen % 8; i++) {
         if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; }
       }
-      // Optimization: Reading values into local variables (v0 to v7) within the
-      // unrolled block before sequential comparisons avoids redundant TypedArray
-      // index lookups and bounds-checking overhead in V8 when a new max is found.
+      // Optimization: Unlike heavy accumulation loops, this pure branch loop is
+      // >10% faster in V8 using direct array access rather than caching values to
+      // local variables first, as it avoids forced assignment overhead on every iteration.
       for (; i < tLen; i += 8) {
-        const v0 = tokenLogits[i];
-        const v1 = tokenLogits[i+1];
-        const v2 = tokenLogits[i+2];
-        const v3 = tokenLogits[i+3];
-        const v4 = tokenLogits[i+4];
-        const v5 = tokenLogits[i+5];
-        const v6 = tokenLogits[i+6];
-        const v7 = tokenLogits[i+7];
-        if (v0 > maxLogit) { maxLogit = v0; maxId = i; }
-        if (v1 > maxLogit) { maxLogit = v1; maxId = i + 1; }
-        if (v2 > maxLogit) { maxLogit = v2; maxId = i + 2; }
-        if (v3 > maxLogit) { maxLogit = v3; maxId = i + 3; }
-        if (v4 > maxLogit) { maxLogit = v4; maxId = i + 4; }
-        if (v5 > maxLogit) { maxLogit = v5; maxId = i + 5; }
-        if (v6 > maxLogit) { maxLogit = v6; maxId = i + 6; }
-        if (v7 > maxLogit) { maxLogit = v7; maxId = i + 7; }
+        if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; }
+        if (tokenLogits[i+1] > maxLogit) { maxLogit = tokenLogits[i+1]; maxId = i + 1; }
+        if (tokenLogits[i+2] > maxLogit) { maxLogit = tokenLogits[i+2]; maxId = i + 2; }
+        if (tokenLogits[i+3] > maxLogit) { maxLogit = tokenLogits[i+3]; maxId = i + 3; }
+        if (tokenLogits[i+4] > maxLogit) { maxLogit = tokenLogits[i+4]; maxId = i + 4; }
+        if (tokenLogits[i+5] > maxLogit) { maxLogit = tokenLogits[i+5]; maxId = i + 5; }
+        if (tokenLogits[i+6] > maxLogit) { maxLogit = tokenLogits[i+6]; maxId = i + 6; }
+        if (tokenLogits[i+7] > maxLogit) { maxLogit = tokenLogits[i+7]; maxId = i + 7; }
       }
 
       // Compute maxVal (scaled) only if needed for softmax stability or logProbs


### PR DESCRIPTION
**What changed**
The 8x unrolled `argmax` loop in `src/parakeet.js` (lines 811-831) previously cached `Float32Array` values into local variables (`v0`...`v7`) before performing condition checks. It has been updated to use direct array accesses (e.g., `if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; }`).

**Why it was needed (bottleneck evidence)**
While loop unrolling is effective for numerical accumulations (as already noted in the journal), caching intermediate variables forces an assignment on *every* loop iteration. For a pure branch operation like `argmax`, where the `maxLogit` is updated infrequently, these forced assignments add unnecessary overhead. Benchmarks demonstrate that direct TypedArray access performs better for this specific pattern in V8.

**Impact (numbers or clearly repeatable observation)**
A standalone benchmark running 100,000 iterations over a 4000-element `Float32Array` demonstrated that direct access completes in ~461 ms compared to ~540-581 ms for the cached variable version. This yields an approximate 15-20% speedup in the hot argmax path without functional changes.

**How to verify (exact steps/commands)**
1. Run `node -e "
import { performance } from 'perf_hooks';
const tLen = 4000;
const tokenLogits = new Float32Array(tLen);
for (let i = 0; i < tLen; i++) tokenLogits[i] = Math.random();
tokenLogits[3000] = 2.0;

function argmaxDirect() {
  let maxLogit = -Infinity, maxId = 0;
  let i = 0;
  for (; i < tLen % 8; i++) { if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; } }
  for (; i < tLen; i += 8) {
    if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; }
    if (tokenLogits[i+1] > maxLogit) { maxLogit = tokenLogits[i+1]; maxId = i + 1; }
    if (tokenLogits[i+2] > maxLogit) { maxLogit = tokenLogits[i+2]; maxId = i + 2; }
    if (tokenLogits[i+3] > maxLogit) { maxLogit = tokenLogits[i+3]; maxId = i + 3; }
    if (tokenLogits[i+4] > maxLogit) { maxLogit = tokenLogits[i+4]; maxId = i + 4; }
    if (tokenLogits[i+5] > maxLogit) { maxLogit = tokenLogits[i+5]; maxId = i + 5; }
    if (tokenLogits[i+6] > maxLogit) { maxLogit = tokenLogits[i+6]; maxId = i + 6; }
    if (tokenLogits[i+7] > maxLogit) { maxLogit = tokenLogits[i+7]; maxId = i + 7; }
  }
  return maxId;
}

function argmaxCached() {
  let maxLogit = -Infinity, maxId = 0;
  let i = 0;
  for (; i < tLen % 8; i++) { if (tokenLogits[i] > maxLogit) { maxLogit = tokenLogits[i]; maxId = i; } }
  for (; i < tLen; i += 8) {
    const v0 = tokenLogits[i]; const v1 = tokenLogits[i+1]; const v2 = tokenLogits[i+2]; const v3 = tokenLogits[i+3];
    const v4 = tokenLogits[i+4]; const v5 = tokenLogits[i+5]; const v6 = tokenLogits[i+6]; const v7 = tokenLogits[i+7];
    if (v0 > maxLogit) { maxLogit = v0; maxId = i; }
    if (v1 > maxLogit) { maxLogit = v1; maxId = i + 1; }
    if (v2 > maxLogit) { maxLogit = v2; maxId = i + 2; }
    if (v3 > maxLogit) { maxLogit = v3; maxId = i + 3; }
    if (v4 > maxLogit) { maxLogit = v4; maxId = i + 4; }
    if (v5 > maxLogit) { maxLogit = v5; maxId = i + 5; }
    if (v6 > maxLogit) { maxLogit = v6; maxId = i + 6; }
    if (v7 > maxLogit) { maxLogit = v7; maxId = i + 7; }
  }
  return maxId;
}

// Warmup
for (let i = 0; i < 10000; i++) { argmaxDirect(); argmaxCached(); }

const start1 = performance.now();
for (let i = 0; i < 100000; i++) argmaxDirect();
const end1 = performance.now();

const start2 = performance.now();
for (let i = 0; i < 100000; i++) argmaxCached();
const end2 = performance.now();

console.log('Direct 8x: ' + (end1 - start1).toFixed(2) + ' ms');
console.log('Cached 8x: ' + (end2 - start2).toFixed(2) + ' ms');
"
`
2. Observe `Direct 8x` completes in less time than `Cached 8x`.
3. To test the change functionality: install `vitest` manually (`npm i vitest`), run `npx vitest`, and confirm all 131 tests pass. Restore `package.json` to avoid committing the dependency modification.

---
*PR created automatically by Jules for task [469946989732640330](https://jules.google.com/task/469946989732640330) started by @ysdede*

## Summary by Sourcery

Optimize the ParakeetModel argmax hot path by changing the unrolled loop to use direct TypedArray access instead of cached local variables and document the performance finding in the project journal.

Enhancements:
- Refine the 8x-unrolled Float32Array argmax implementation to compare directly against tokenLogits indices, reducing per-iteration overhead while preserving behavior.

Documentation:
- Extend the performance tuning journal with guidance that pure branch loops over TypedArrays should use direct array access in unrolled argmax-style patterns rather than caching elements to locals.