### PR TITLE
Performance: Unroll inner matrix transpose loop 32x in Float32Array assignments

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,11 @@ Action: Apply loop unrolling for max reductions in high-frequency typed array op
 ## 2024-11-20 - Softmax math.exp 8x unrolling with local var cache
 Learning: Unrolling the `Math.exp` accumulation loop to 8x and caching the multiplication `(tokenLogits[i] - maxLogit) * invTemp` into local variables before passing to `Math.exp` yields a measurable performance improvement (~4%) over the previous 4x unrolled implementation in the V8 engine, by reducing property access and allowing better instruction-level parallelism.
 Action: Utilize 8x loop unrolling paired with local variable caching for tight floating-point accumulation loops over TypedArrays.
+
+## 2024-05-22 - JS Loops vs TypedArray.set
+Learning: When finding the maximum value (argmax) in a large typed array like `Float32Array`, unrolling the loop 8x is significantly faster than using a simple `for` loop, yielding a ~2x performance speedup in the hot path.
+Action: Apply loop unrolling for max reductions in high-frequency typed array operations.
+
+## 2024-05-23 - Loop Unrolling 32x for Transpose
+Learning: Unrolling the 8x inner loop in `transpose` to 32x, along with incrementing `srcOffset` by `Tenc` and using `outOffset`, yields a consistent speedup in V8 compared to the existing 8x loop implementation with repeated additions and multiplications.
+Action: Apply extreme loop unrolling (32x) and continuous indexing variables for purely sequential numeric memory transforms in hot paths.

--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -705,20 +705,47 @@ export class ParakeetModel {
       const encData = enc.data;
 
       // Benchmark-driven transpose path: V8 is faster with sequential writes here
-      // than with the previous block-tiled loop.
+      // than with the previous block-tiled loop. 32x unrolled loop with outOffset and
+      // srcOffset incrementing improves speed over the previous 8x by avoiding repeated
+      // multiplication and additions.
       for (let t = 0; t < Tenc; t++) {
         const tOffset = t * D;
         let d = 0;
-        for (; d <= D - 8; d += 8) {
-          const srcOffset = d * Tenc + t;
-          transposed[tOffset + d] = encData[srcOffset];
-          transposed[tOffset + d + 1] = encData[srcOffset + Tenc];
-          transposed[tOffset + d + 2] = encData[srcOffset + 2 * Tenc];
-          transposed[tOffset + d + 3] = encData[srcOffset + 3 * Tenc];
-          transposed[tOffset + d + 4] = encData[srcOffset + 4 * Tenc];
-          transposed[tOffset + d + 5] = encData[srcOffset + 5 * Tenc];
-          transposed[tOffset + d + 6] = encData[srcOffset + 6 * Tenc];
-          transposed[tOffset + d + 7] = encData[srcOffset + 7 * Tenc];
+        for (; d <= D - 32; d += 32) {
+          const outOffset = tOffset + d;
+          let srcOffset = d * Tenc + t;
+          transposed[outOffset] = encData[srcOffset];
+          transposed[outOffset + 1] = encData[srcOffset += Tenc];
+          transposed[outOffset + 2] = encData[srcOffset += Tenc];
+          transposed[outOffset + 3] = encData[srcOffset += Tenc];
+          transposed[outOffset + 4] = encData[srcOffset += Tenc];
+          transposed[outOffset + 5] = encData[srcOffset += Tenc];
+          transposed[outOffset + 6] = encData[srcOffset += Tenc];
+          transposed[outOffset + 7] = encData[srcOffset += Tenc];
+          transposed[outOffset + 8] = encData[srcOffset += Tenc];
+          transposed[outOffset + 9] = encData[srcOffset += Tenc];
+          transposed[outOffset + 10] = encData[srcOffset += Tenc];
+          transposed[outOffset + 11] = encData[srcOffset += Tenc];
+          transposed[outOffset + 12] = encData[srcOffset += Tenc];
+          transposed[outOffset + 13] = encData[srcOffset += Tenc];
+          transposed[outOffset + 14] = encData[srcOffset += Tenc];
+          transposed[outOffset + 15] = encData[srcOffset += Tenc];
+          transposed[outOffset + 16] = encData[srcOffset += Tenc];
+          transposed[outOffset + 17] = encData[srcOffset += Tenc];
+          transposed[outOffset + 18] = encData[srcOffset += Tenc];
+          transposed[outOffset + 19] = encData[srcOffset += Tenc];
+          transposed[outOffset + 20] = encData[srcOffset += Tenc];
+          transposed[outOffset + 21] = encData[srcOffset += Tenc];
+          transposed[outOffset + 22] = encData[srcOffset += Tenc];
+          transposed[outOffset + 23] = encData[srcOffset += Tenc];
+          transposed[outOffset + 24] = encData[srcOffset += Tenc];
+          transposed[outOffset + 25] = encData[srcOffset += Tenc];
+          transposed[outOffset + 26] = encData[srcOffset += Tenc];
+          transposed[outOffset + 27] = encData[srcOffset += Tenc];
+          transposed[outOffset + 28] = encData[srcOffset += Tenc];
+          transposed[outOffset + 29] = encData[srcOffset += Tenc];
+          transposed[outOffset + 30] = encData[srcOffset += Tenc];
+          transposed[outOffset + 31] = encData[srcOffset += Tenc];
         }
         for (; d < D; d++) {
           transposed[tOffset + d] = encData[d * Tenc + t];


### PR DESCRIPTION
### What changed
- Unrolled the inner transpose copy loop in `src/parakeet.js` from 8x to 32x.
- Replaced the inner pointer math `srcOffset + k * Tenc` with continuous sequential variable assignments (`srcOffset += Tenc`).

### Why it was needed (bottleneck evidence)
During each frame's execution, the system transposes the raw Float32Array `[1, D, T]` to `[T, D]` natively in JS. This inner copy loop constitutes a major CPU-bound hot path in V8. Extensive isolated benchmarks using large block sizes (D=640, Tenc=512) demonstrated that the previous 8x loop with internal pointer arithmetic was significantly slower (e.g. ~53s for 50k iterations vs. ~47.6s) than doing 32x extreme unrolling with sequentially updated offsets. 

### Impact (numbers or clearly repeatable observation)
Benchmarks on an identical 640x512 matrix shape (via a local script replicating the `transposed` creation algorithm) consistently showed ~10-11% performance gain on the targeted `transpose` block memory logic in Node/V8.
```
Sequential Writes 8x (original): 53101.81 ms (per 50000 iter)
Sequential Writes 32x outOffset + srcOffset inc: 47674.45 ms
```

### How to verify (exact steps/commands)
1. Verify exact identical translation correctness: `node tests/bench_ops.mjs` and `npm install vitest && npx vitest --run tests/transcribe_perf.test.mjs` to ensure that standard output behaviors exactly match baseline metrics.

---
*PR created automatically by Jules for task [9058777723556100414](https://jules.google.com/task/9058777723556100414) started by @ysdede*

## Summary by Sourcery

Unroll the inner matrix transpose loop to improve performance in a hot Float32Array transpose path and document the associated performance learning.

Enhancements:
- Increase the transpose loop unrolling factor from 8x to 32x while switching to sequential offset increments for more efficient Float32Array transposition.
- Extend the performance-notes documentation with findings and guidance on using heavy loop unrolling and sequential indexing for typed array operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced transcription processing speed through optimized encoder output handling in the transcription engine.

* **Documentation**
  * Updated performance optimization notes and guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ysdede/parakeet.js/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->