### PR TITLE
Code health: Remove duplicate comment in backend.js

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -101,7 +101,6 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
   }
 
   // Store the final backend choice for use in model selection
-  // Store the final backend choice for use in model selection
   // ort._selectedBackend = backend; // Removed: ort object is not extensible in newer versions
 
   // Expose ort globally so other modules (like SileroVAD) can use the same configured instance


### PR DESCRIPTION
## Summary
Removes a duplicate comment line in `src/backend.js`.

## Changes
- Deletes one redundant comment.
- No runtime behavior change.