### PR TITLE
Performance: Use native string keys for sentence cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@ Action: Apply loop unrolling for max reductions in high-frequency typed array op
 ## 2024-11-20 - Softmax math.exp 8x unrolling with local var cache
 Learning: Unrolling the `Math.exp` accumulation loop to 8x and caching the multiplication `(tokenLogits[i] - maxLogit) * invTemp` into local variables before passing to `Math.exp` yields a measurable performance improvement (~4%) over the previous 4x unrolled implementation in the V8 engine, by reducing property access and allowing better instruction-level parallelism.
 Action: Utilize 8x loop unrolling paired with local variable caching for tight floating-point accumulation loops over TypedArrays.
+
+## 2024-05-18 - String Hashing for Map Keys
+Learning: In V8 (JavaScript), computing string hashes character-by-character (e.g., manual djb2 loops) is extremely slow compared to native map string key lookups, and manual 32-bit hashes risk collision bugs.
+Action: Never manually hash string keys for JS Maps or Sets; simply pass the string directly and allow the V8 engine to handle hashing internally in C++.

--- a/src/sentence_boundary.js
+++ b/src/sentence_boundary.js
@@ -333,14 +333,7 @@ export class SentenceBoundaryDetector {
   }
 
   generateCacheKey(text) {
-    let hash = 0;
-    if (text.length === 0) return hash.toString();
-    for (let i = 0; i < text.length; i += 1) {
-      const char = text.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash &= hash;
-    }
-    return hash.toString();
+    return text;
   }
 
   addToCache(key, value) {


### PR DESCRIPTION
## Summary
Replaces manual hash generation for sentence-boundary cache keys with direct string keys.

## Changes
- `generateCacheKey(text)` now returns `text` directly.
- Adds a short performance note in `.jules/bolt.md`.

## Notes
Please evaluate memory tradeoffs for very large inputs when storing raw strings as keys.