### PR TITLE
fix(tests): clear hub repo file cache between quantization tests

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -15,6 +15,14 @@ let dbPromise = null;
 // Cache successful lookups only. Failed lookups intentionally do not cache.
 const repoFileCache = new Map();
 
+/**
+ * Clear the repo file listing cache. Exported for test determinism only;
+ * production code does not need to call this.
+ */
+export function clearRepoFileCache() {
+  repoFileCache.clear();
+}
+
 const QUANT_SUFFIX = {
   int8: '.int8.onnx',
   fp16: '.fp16.onnx',

--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getParakeetModel } from '../src/hub.js';
+import { clearRepoFileCache, getParakeetModel } from '../src/hub.js';
 
 function jsonResponse(payload, status = 200) {
   return new Response(JSON.stringify(payload), {
@@ -86,6 +86,7 @@ function installFetchMock({
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  clearRepoFileCache();
 });
 
 describe('getParakeetModel quantization resolution (strict mode)', () => {


### PR DESCRIPTION
Export clearRepoFileCache() from src/hub.js and call it in afterEach to prevent cross-test cache pollution. Makes test ordering deterministic regardless of repo ID reuse.

Closes #82