### PR TITLE
perf(demo): lazy-load persisted settings with useState initializer

### DIFF
--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -660,7 +660,7 @@ function pcmToWavBlob(pcm, sampleRate = 16000) {
 }
 
 export default function App() {
-  const initialSettings = loadSettings();
+  const [initialSettings] = useState(() => loadSettings());
   const initialSelectedModel = initialSettings.selectedModel;
   const initialModelSource = initialSettings.modelSource;
   const resolvedInitialModel = MODELS[initialSelectedModel] ? initialSelectedModel : 'parakeet-tdt-0.6b-v2';


### PR DESCRIPTION
Wrap loadSettings() in useState(() => loadSettings()) so localStorage.getItem + JSON.parse runs only on mount, not on every render.

Closes #81