### PR TITLE
fix(tokenizer): remove heuristic space-stripping regex

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -55,8 +55,12 @@ export class ParakeetTokenizer {
 
   /**
    * Decode an array of token IDs into a human readable string.
-   * Implements the SentencePiece rule where leading `▁` marks a space.
-   * Matches the Python reference regex pattern: r"\A\s|\s\B|(\s)\b"
+   * Implements the SentencePiece rule where leading ▁ marks a word boundary.
+   *
+   * The native SentencePiece decode_ids() joins pieces after ▁ → space
+   * conversion with NO additional regex post-processing. We mirror that here:
+   * ▁word → " word", word-without-▁ attaches directly to the previous token.
+   *
    * @param {number[]} ids - Token IDs from decoder output.
    * @returns {string} Decoded transcript text.
    */
@@ -70,18 +74,16 @@ export class ParakeetTokenizer {
       tokens.push(token);
     }
 
-    // Join all tokens
+    // Join all tokens. SentencePiece ▁ markers already encode word boundaries
+    // correctly — ▁word gets a space, word-without-▁ attaches directly.
+    // Native SentencePiece decode_ids() does no regex post-processing beyond
+    // ▁ → space conversion, so we mirror that behavior here.
     let text = tokens.join('');
 
-    // Apply the same regex pattern as Python reference:
-    // Pattern: r"\A\s|\s\B|(\s)\b"
-    // - \A\s: Remove leading whitespace
-    // - \s\B: Remove whitespace before non-word boundaries
-    // - (\s)\b: Keep space at word boundaries (captured group)
-    text = text.replace(/^\s+/, '');  // Remove leading whitespace (\A\s)
-    text = text.replace(/\s+(?=[^\w\s])/g, '');  // Remove space before punctuation (\s\B approximation)
+    // Safe cleanups only (no heuristic space removal)
+    text = text.replace(/^\s+/, '');  // Remove leading whitespace
     text = text.replace(/\s+/g, ' ');  // Normalize multiple spaces to single space
 
     return text.trim();
   }
-} 
+}

--- a/tests/tokenizer.test.mjs
+++ b/tests/tokenizer.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { ParakeetTokenizer } from '../src/tokenizer.js';
+
+/**
+ * Build a minimal tokenizer with known ▁-prefixed tokens.
+ */
+function buildTokenizer(tokens) {
+  return new ParakeetTokenizer(tokens);
+}
+
+describe('ParakeetTokenizer.decode', () => {
+  it('preserves space before dollar sign (currency)', () => {
+    // SentencePiece: "▁another" + "▁$3,000" → "another $3,000"
+    const tokenizer = buildTokenizer(['another', ' $3,000']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('another $3,000');
+  });
+
+  it('preserves space before dollar sign mid-sentence', () => {
+    const tokenizer = buildTokenizer(['about', ' $50,000']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('about $50,000');
+  });
+
+  it('preserves space before euro sign', () => {
+    const tokenizer = buildTokenizer(['cost', ' €50']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('cost €50');
+  });
+
+  it('preserves space before pound sign', () => {
+    const tokenizer = buildTokenizer(['paid', ' £100']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('paid £100');
+  });
+
+  it('preserves space before turkish lira sign', () => {
+    const tokenizer = buildTokenizer(['fiyat', ' ₺500']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('fiyat ₺500');
+  });
+
+  it('attaches punctuation without ▁ marker', () => {
+    // SentencePiece: "▁hello" + "." → "hello." (no ▁ on punctuation)
+    const tokenizer = buildTokenizer(['hello', '.']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('hello.');
+  });
+
+  it('attaches comma without ▁ marker', () => {
+    const tokenizer = buildTokenizer(['hello', ',', ' world']);
+    const result = tokenizer.decode([0, 1, 2]);
+    expect(result).toBe('hello, world');
+  });
+
+  it('removes leading whitespace from first token', () => {
+    const tokenizer = buildTokenizer([' hello', ' world']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('hello world');
+  });
+
+  it('does not add space when dollar sign is leading token', () => {
+    const tokenizer = buildTokenizer(['$3,000', ' is']);
+    const result = tokenizer.decode([0, 1]);
+    expect(result).toBe('$3,000 is');
+  });
+});


### PR DESCRIPTION
The \\s\\B regex was incorrectly removing intentional spaces before currency symbols and other non-word characters. SentencePiece ▁ markers already encode word boundaries  native decode_ids() does no regex post-processing.

Dropped the heuristic and only kept safe cleanups (leading whitespace, normalize runs). Added 9 tokenizer tests. All 140 tests pass.

Closes #99