### PR TITLE
fix(demo): retry FP32 only on FP16-related errors

### DIFF
--- a/examples/demo/src/shared/modelLoader.js
+++ b/examples/demo/src/shared/modelLoader.js
@@ -23,6 +23,28 @@ function shouldRetryWithFp32(quantisation) {
   return quantisation?.encoder === 'fp16' || quantisation?.decoder === 'fp16';
 }
 
+/**
+ * Check whether an error is likely FP16-related (compilation/capability).
+ * Only these errors warrant an FP32 fallback retry; other errors should
+ * propagate directly to avoid wasted re-download and re-compile cycles.
+ *
+ * @param {*} err - Error from ORT session creation or model compilation.
+ * @param {{encoder: string, decoder: string}} quantisation - Resolved quantization.
+ * @returns {boolean}
+ */
+function isFp16RelatedError(err, quantisation) {
+  const message = (err?.message || String(err)).toLowerCase();
+  // Direct FP16 mentions in error
+  if (message.includes('fp16')) return true;
+  // ORT session creation / compilation failures when FP16 was requested
+  if (quantisation?.encoder === 'fp16' || quantisation?.decoder === 'fp16') {
+    if (message.includes('compile') || message.includes('session') || message.includes('create')) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function buildRetryOptions(options, quantisation) {
   const retryOptions = { ...options };
   if (quantisation?.encoder === 'fp16') retryOptions.encoderQuant = 'fp32';
@@ -55,7 +77,7 @@ export async function loadModelWithFallback({
     const model = await fromUrlsFn(toFromUrlsConfig(firstModelUrls, options));
     return { model, modelUrls: firstModelUrls, retryUsed: false };
   } catch (firstError) {
-    if (!shouldRetryWithFp32(firstModelUrls.quantisation)) {
+    if (!shouldRetryWithFp32(firstModelUrls.quantisation) || !isFp16RelatedError(firstError, firstModelUrls.quantisation)) {
       throw firstError;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "WebGPU speech recognition for NVIDIA Parakeet in the browser, powered by ONNX Runtime Web.",
   "type": "module",
   "types": "./types/index.d.ts",

--- a/tests/model-loader-fp16-retry.test.mjs
+++ b/tests/model-loader-fp16-retry.test.mjs
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadModelWithFallback } from '../examples/demo/src/shared/modelLoader.js';
+
+function stubModelUrls(overrides = {}) {
+  return {
+    urls: { encoderUrl: 'blob:enc', decoderUrl: 'blob:dec', tokenizerUrl: 'blob:vocab' },
+    filenames: { encoder: 'enc.onnx', decoder: 'dec.onnx' },
+    preprocessorBackend: 'js',
+    quantisation: { encoder: 'fp16', decoder: 'fp16', ...overrides.quantisation },
+    ...overrides,
+  };
+}
+
+function stubOptions() {
+  return { backend: 'webgpu', encoderQuant: 'fp16', decoderQuant: 'fp16' };
+}
+
+describe('loadModelWithFallback FP16 retry scoping', () => {
+  it('retries with FP32 on FP16 compile failure', async () => {
+    const getModelFn = vi.fn().mockResolvedValue(stubModelUrls());
+    const fromUrlsFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('compile failed'))
+      .mockResolvedValueOnce({});
+
+    const result = await loadModelWithFallback({
+      repoIdOrModelKey: 'test/model',
+      options: stubOptions(),
+      getParakeetModelFn: getModelFn,
+      fromUrlsFn,
+    });
+
+    expect(result.retryUsed).toBe(true);
+    expect(getModelFn).toHaveBeenCalledTimes(2);
+    expect(getModelFn.mock.calls[1][1].encoderQuant).toBe('fp32');
+    expect(getModelFn.mock.calls[1][1].decoderQuant).toBe('fp32');
+  });
+
+  it('does NOT retry when no FP16 quantization was requested', async () => {
+    const getModelFn = vi.fn().mockResolvedValue(stubModelUrls({
+      quantisation: { encoder: 'fp32', decoder: 'int8' },
+    }));
+    const fromUrlsFn = vi.fn().mockRejectedValue(new Error('compile failed'));
+
+    await expect(
+      loadModelWithFallback({
+        repoIdOrModelKey: 'test/model',
+        options: { ...stubOptions(), encoderQuant: 'fp32', decoderQuant: 'int8' },
+        getParakeetModelFn: getModelFn,
+        fromUrlsFn,
+      })
+    ).rejects.toThrow('compile failed');
+
+    expect(getModelFn).toHaveBeenCalledTimes(1); // no retry
+  });
+
+  it('does NOT retry on non-compile errors even with FP16', async () => {
+    const getModelFn = vi.fn().mockResolvedValue(stubModelUrls());
+    const fromUrlsFn = vi.fn().mockRejectedValue(new Error('network error'));
+
+    await expect(
+      loadModelWithFallback({
+        repoIdOrModelKey: 'test/model',
+        options: stubOptions(),
+        getParakeetModelFn: getModelFn,
+        fromUrlsFn,
+      })
+    ).rejects.toThrow('network error');
+
+    expect(getModelFn).toHaveBeenCalledTimes(1); // no retry
+  });
+
+  it('retries on session creation failure with FP16', async () => {
+    const getModelFn = vi.fn().mockResolvedValue(stubModelUrls());
+    const fromUrlsFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('session creation failed'))
+      .mockResolvedValueOnce({});
+
+    const result = await loadModelWithFallback({
+      repoIdOrModelKey: 'test/model',
+      options: stubOptions(),
+      getParakeetModelFn: getModelFn,
+      fromUrlsFn,
+    });
+
+    expect(result.retryUsed).toBe(true);
+  });
+
+  it('retries when error message contains "fp16" explicitly', async () => {
+    const getModelFn = vi.fn().mockResolvedValue(stubModelUrls({
+      quantisation: { encoder: 'fp16', decoder: 'fp16' },
+    }));
+    const fromUrlsFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('FP16 shader compilation not supported'))
+      .mockResolvedValueOnce({});
+
+    const result = await loadModelWithFallback({
+      repoIdOrModelKey: 'test/model',
+      options: stubOptions(),
+      getParakeetModelFn: getModelFn,
+      fromUrlsFn,
+    });
+
+    expect(result.retryUsed).toBe(true);
+  });
+});


### PR DESCRIPTION
Add isFp16RelatedError() classifier  checks error message for FP16 keywords and ORT compile/session/create failures. Non-FP16 errors (network, etc.) now propagate directly without wasted re-download.

Closes #79