### PR TITLE
fix: guard ORT init against concurrent fromUrls callers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "WebGPU speech recognition for NVIDIA Parakeet in the browser, powered by ONNX Runtime Web.",
   "type": "module",
   "types": "./types/index.d.ts",

--- a/src/backend.js
+++ b/src/backend.js
@@ -2,18 +2,28 @@
 // At runtime the caller can specify preferred backend ("webgpu", "wasm").
 // The function resolves once ONNX Runtime is ready and returns the `ort` module.
 
+// Singleton promise: initOrt is NOT re-entrant — concurrent callers
+// must share the same initialization to avoid double WASM init races.
+let _initPromise = null;
+
 /**
  * Initialise ONNX Runtime Web and pick the execution provider.
  * If WebGPU is requested but not supported, we transparently fall back to WASM.
  * Higher-level APIs may accept `'webgpu-hybrid'`/`'webgpu-strict'` and normalize
  * those values to `'webgpu'` before calling this low-level initializer.
+ *
+ * Concurrent calls are safe — the first caller's initialization is shared.
+ *
  * @param {Object} opts
  * @param {('webgpu'|'wasm')} [opts.backend='webgpu'] Desired backend.
  * @param {string} [opts.wasmPaths] Optional path prefix for WASM binaries.
  * @param {number} [opts.numThreads] Number of WASM threads to use when SharedArrayBuffer is available.
  * @returns {Promise<typeof import('onnxruntime-web').default>}
  */
-export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
+export function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
+  if (_initPromise) return _initPromise;
+
+  _initPromise = (async () => {
   // Dynamic import to handle Vite bundling issues
   let ort;
 
@@ -111,4 +121,7 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
 
   // Return the ort module for use in creating sessions and tensors
   return ort;
+  })();
+
+  return _initPromise;
 }

--- a/tests/backend-init.test.mjs
+++ b/tests/backend-init.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { initOrt } from '../src/backend.js';
+
+describe('initOrt singleton', () => {
+  it('returns the same promise on concurrent calls', () => {
+    const p1 = initOrt({ backend: 'wasm' });
+    const p2 = initOrt({ backend: 'wasm' });
+    expect(p1).toBe(p2); // same promise object — no duplicate init
+  });
+
+  it('resolves to the ort module', async () => {
+    const ort = await initOrt({ backend: 'wasm' });
+    expect(ort).toBeDefined();
+    expect(typeof ort.InferenceSession?.create).toBe('function');
+    expect(typeof ort.Tensor).toBe('function');
+  });
+
+  it('shares result across subsequent calls', async () => {
+    const ort1 = await initOrt({ backend: 'wasm' });
+    const ort2 = await initOrt({ backend: 'wasm' });
+    expect(ort1).toBe(ort2); // same ort instance from shared promise
+  });
+});


### PR DESCRIPTION
Wrap initOrt body in a singleton promise. Concurrent fromUrls calls now share the same ORT init instead of racing to import, configure WASM, and register backends.

Closes #47