### PR TITLE
refactor(demo): extract local-folder helpers from App.jsx

### DIFF
--- a/examples/demo/src/App.jsx
+++ b/examples/demo/src/App.jsx
@@ -7,6 +7,21 @@ import {
   pickPreferredQuant,
 } from './shared/modelSelection.js';
 import { formatResolvedQuantization, loadModelWithFallback } from './shared/modelLoader.js';
+import {
+  supportsDirectoryHandlePersistence,
+  readPersistedDirectoryHandle,
+  persistDirectoryHandle,
+  clearPersistedDirectoryHandle,
+} from './shared/localModelStorage.js';
+import {
+  normalizeRelPath,
+  getBasename,
+  detectLocalQuantModes,
+  findLocalEntry,
+  quantizedModelName,
+  collectDirectoryFilesRecursive,
+  getLocalFile,
+} from './shared/localModelArtifacts.js';
 import warmupAudioUrl from './assets/Harvard-L2-1.ogg?url';
 import './App.css';
 
@@ -341,155 +356,6 @@ async function getEntryFile(entry) {
   throw new Error(`Could not access local file entry: ${entry?.path || entry?.basename || 'unknown'}`);
 }
 
-function supportsDirectoryHandlePersistence() {
-  if (typeof window === 'undefined' || typeof window.showDirectoryPicker !== 'function' || typeof indexedDB === 'undefined') return false;
-  // showDirectoryPicker is blocked in cross-origin iframes (e.g. HF Spaces)
-  try { if (window.self !== window.top) return false; } catch { return false; }
-  return true;
-}
-
-function openLocalModelDb() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(LOCAL_MODEL_DB_NAME, 1);
-    request.onerror = () => reject(new Error('Failed to open local model IndexedDB'));
-    request.onsuccess = () => resolve(request.result);
-    request.onupgradeneeded = (event) => {
-      const db = event.target.result;
-      if (!db.objectStoreNames.contains(LOCAL_MODEL_STORE_NAME)) {
-        db.createObjectStore(LOCAL_MODEL_STORE_NAME);
-      }
-    };
-  });
-}
-
-async function readPersistedDirectoryHandle() {
-  const db = await openLocalModelDb();
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const closeDb = () => {
-      try {
-        db.close();
-      } catch {
-        // Ignore close errors.
-      }
-    };
-    const resolveOnce = (value) => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-    };
-    const rejectOnce = (error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    };
-    const tx = db.transaction([LOCAL_MODEL_STORE_NAME], 'readonly');
-    const store = tx.objectStore(LOCAL_MODEL_STORE_NAME);
-    const req = store.get(LOCAL_MODEL_DIR_KEY);
-    req.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to read persisted folder handle'));
-    };
-    req.onsuccess = () => {
-      closeDb();
-      resolveOnce(req.result || null);
-    };
-    tx.onabort = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to read persisted folder handle'));
-    };
-    tx.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to read persisted folder handle'));
-    };
-  });
-}
-
-async function persistDirectoryHandle(dirHandle) {
-  const db = await openLocalModelDb();
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const closeDb = () => {
-      try {
-        db.close();
-      } catch {
-        // Ignore close errors.
-      }
-    };
-    const resolveOnce = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    const rejectOnce = (error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    };
-    const tx = db.transaction([LOCAL_MODEL_STORE_NAME], 'readwrite');
-    const store = tx.objectStore(LOCAL_MODEL_STORE_NAME);
-    const req = store.put(dirHandle, LOCAL_MODEL_DIR_KEY);
-    req.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to persist folder handle'));
-    };
-    req.onsuccess = () => {
-      closeDb();
-      resolveOnce();
-    };
-    tx.onabort = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to persist folder handle'));
-    };
-    tx.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to persist folder handle'));
-    };
-  });
-}
-
-async function clearPersistedDirectoryHandle() {
-  const db = await openLocalModelDb();
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const closeDb = () => {
-      try {
-        db.close();
-      } catch {
-        // Ignore close errors.
-      }
-    };
-    const resolveOnce = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    const rejectOnce = (error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    };
-    const tx = db.transaction([LOCAL_MODEL_STORE_NAME], 'readwrite');
-    const store = tx.objectStore(LOCAL_MODEL_STORE_NAME);
-    const req = store.delete(LOCAL_MODEL_DIR_KEY);
-    req.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to clear persisted folder handle'));
-    };
-    req.onsuccess = () => {
-      closeDb();
-      resolveOnce();
-    };
-    tx.onabort = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to clear persisted folder handle'));
-    };
-    tx.onerror = () => {
-      closeDb();
-      rejectOnce(new Error('Failed to clear persisted folder handle'));
-    };
-  });
-}
 
 function parseThemeValue(value) {
   if (typeof value !== 'string') return null;

--- a/examples/demo/src/shared/localModelArtifacts.js
+++ b/examples/demo/src/shared/localModelArtifacts.js
@@ -1,0 +1,106 @@
+/**
+ * Local-folder model artifact detection and URL assembly helpers.
+ * Extracted from App.jsx — pure functions with no React dependency.
+ */
+
+const QUANT_TO_FILENAME = {
+  fp32: '.onnx',
+  fp16: '.fp16.onnx',
+  int8: '.int8.onnx',
+};
+
+/** Normalize backslashes and leading ./ in relative paths. */
+export function normalizeRelPath(path) {
+  return String(path || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+export function getBasename(path) {
+  return String(path || '').split('/').pop() || '';
+}
+
+/** Detect which quantization modes are available in a set of local entries. */
+export function detectLocalQuantModes(entries, baseName) {
+  const names = new Set(entries.map((entry) => entry.basename.toLowerCase()));
+  const out = [];
+  if (names.has(`${baseName}.onnx`)) out.push('fp32');
+  if (names.has(`${baseName}.fp16.onnx`)) out.push('fp16');
+  if (names.has(`${baseName}.int8.onnx`)) out.push('int8');
+  return out;
+}
+
+/** Find a local entry by expected filename (case-insensitive). */
+export function findLocalEntry(entries, expectedName) {
+  const lower = expectedName.toLowerCase();
+  return (
+    entries.find((entry) => entry.path.toLowerCase() === lower) ||
+    entries.find((entry) => entry.basename.toLowerCase() === lower) ||
+    entries.find((entry) => entry.path.toLowerCase().endsWith(`/${lower}`)) ||
+    null
+  );
+}
+
+export function quantizedModelName(baseName, quant) {
+  return `${baseName}${QUANT_TO_FILENAME[quant] || '.onnx'}`;
+}
+
+/** Collect all files from a directory handle recursively. */
+export async function collectDirectoryFilesRecursive(dirHandle) {
+  /** @type {Array<{path: string, basename: string, handle: FileSystemHandle}>} */
+  const entries = [];
+  async function walk(handle, prefix = '') {
+    if (handle.kind === 'file') {
+      entries.push({
+        path: prefix ? `${prefix}/${handle.name}` : handle.name,
+        basename: handle.name,
+        handle,
+      });
+      return;
+    }
+    for await (const entry of handle.values()) {
+      await walk(entry, prefix ? `${prefix}/${handle.name}` : handle.name);
+    }
+  }
+  await walk(dirHandle);
+  return entries;
+}
+
+/** Get a File object from a local file-handle entry. */
+export async function getLocalFile(entry) {
+  if (entry.file) return entry.file;
+  if (entry.handle?.kind === 'file') return entry.handle.getFile();
+  throw new Error(`Could not access local file entry: ${entry?.path || entry?.basename || 'unknown'}`);
+}
+
+/** Build blob URLs for local model artifacts and return the cleanup list. */
+export async function buildLocalModelUrls(entries, {
+  encoderEntry,
+  decoderEntry,
+  tokenizerEntry,
+  preprocessorEntry,
+}) {
+  const createdBlobUrls = [];
+  try {
+    const encoderFile = encoderEntry ? await getLocalFile(encoderEntry) : null;
+    const decoderFile = decoderEntry ? await getLocalFile(decoderEntry) : null;
+    const tokenizerFile = tokenizerEntry ? await getLocalFile(tokenizerEntry) : null;
+    const preprocessorFile = preprocessorEntry ? await getLocalFile(preprocessorEntry) : null;
+
+    const encoderUrl = encoderFile ? URL.createObjectURL(encoderFile) : null;
+    if (encoderUrl) createdBlobUrls.push(encoderUrl);
+    const decoderUrl = decoderFile ? URL.createObjectURL(decoderFile) : null;
+    if (decoderUrl) createdBlobUrls.push(decoderUrl);
+    const tokenizerUrl = tokenizerFile ? URL.createObjectURL(tokenizerFile) : null;
+    if (tokenizerUrl) createdBlobUrls.push(tokenizerUrl);
+    const preprocessorUrl = preprocessorFile ? URL.createObjectURL(preprocessorFile) : null;
+    if (preprocessorUrl) createdBlobUrls.push(preprocessorUrl);
+
+    return {
+      urls: { encoderUrl, decoderUrl, tokenizerUrl, preprocessorUrl, preprocessorBackend: 'onnx' },
+      createdBlobUrls,
+    };
+  } catch (e) {
+    // Clean up any URLs we already created
+    for (const url of createdBlobUrls) URL.revokeObjectURL(url);
+    throw e;
+  }
+}

--- a/examples/demo/src/shared/localModelStorage.js
+++ b/examples/demo/src/shared/localModelStorage.js
@@ -1,0 +1,85 @@
+/**
+ * IndexedDB persistence for local-folder model directory handles.
+ * Extracted from App.jsx to keep component focused on UI.
+ */
+
+const DB_NAME = 'parakeet-demo-local-model';
+const STORE_NAME = 'handles';
+const DIR_KEY = 'directory-handle';
+
+/** Check whether the File System Access API + IndexedDB are available. */
+export function supportsDirectoryHandlePersistence() {
+  if (typeof window === 'undefined') return false;
+  if (typeof window.showDirectoryPicker !== 'function') return false;
+  if (typeof indexedDB === 'undefined') return false;
+  try { if (window.self !== window.top) return false; } catch { return false; }
+  return true;
+}
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onerror = () => reject(new Error('Failed to open local model IndexedDB'));
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+  });
+}
+
+/** Read a previously persisted FileSystemDirectoryHandle, or null. */
+export async function readPersistedDirectoryHandle() {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const closeDb = () => { try { db.close(); } catch { /* ignore */ } };
+    const resolveOnce = (v) => { if (!settled) { settled = true; resolve(v); } };
+    const rejectOnce = (e) => { if (!settled) { settled = true; reject(e); } };
+    const tx = db.transaction([STORE_NAME], 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.get(DIR_KEY);
+    req.onerror = () => { closeDb(); rejectOnce(new Error('Failed to read persisted folder handle')); };
+    req.onsuccess = () => { closeDb(); resolveOnce(req.result || null); };
+    tx.onabort = () => { closeDb(); rejectOnce(new Error('Failed to read persisted folder handle')); };
+    tx.onerror = () => { closeDb(); rejectOnce(new Error('Failed to read persisted folder handle')); };
+  });
+}
+
+/** Persist a FileSystemDirectoryHandle for future page loads. */
+export async function persistDirectoryHandle(dirHandle) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const closeDb = () => { try { db.close(); } catch { /* ignore */ } };
+    const resolveOnce = () => { if (!settled) { settled = true; resolve(); } };
+    const rejectOnce = (e) => { if (!settled) { settled = true; reject(e); } };
+    const tx = db.transaction([STORE_NAME], 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.put(dirHandle, DIR_KEY);
+    req.onerror = () => { closeDb(); rejectOnce(new Error('Failed to persist folder handle')); };
+    req.onsuccess = () => { closeDb(); resolveOnce(); };
+    tx.onabort = () => { closeDb(); rejectOnce(new Error('Failed to persist folder handle')); };
+    tx.onerror = () => { closeDb(); rejectOnce(new Error('Failed to persist folder handle')); };
+  });
+}
+
+/** Remove the persisted directory handle. */
+export async function clearPersistedDirectoryHandle() {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const closeDb = () => { try { db.close(); } catch { /* ignore */ } };
+    const resolveOnce = () => { if (!settled) { settled = true; resolve(); } };
+    const rejectOnce = (e) => { if (!settled) { settled = true; reject(e); } };
+    const tx = db.transaction([STORE_NAME], 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.delete(DIR_KEY);
+    req.onerror = () => { closeDb(); rejectOnce(new Error('Failed to clear persisted folder handle')); };
+    req.onsuccess = () => { closeDb(); resolveOnce(); };
+    tx.onabort = () => { closeDb(); rejectOnce(new Error('Failed to clear persisted folder handle')); };
+    tx.onerror = () => { closeDb(); rejectOnce(new Error('Failed to clear persisted folder handle')); };
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet.js",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "WebGPU speech recognition for NVIDIA Parakeet in the browser, powered by ONNX Runtime Web.",
   "type": "module",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
Extract IndexedDB persistence (~148 lines) and artifact detection into:
- localModelStorage.js  persistence, read/write/clear handles
- localModelArtifacts.js  quant detection, folder scan, URL assembly

All local-folder behavior preserved with same function signatures and error handling.

Closes #97