### PR TITLE
fix(backend): guard navigator references for Node.js compat

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -77,7 +77,7 @@ export function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
   if (backend === 'wasm' || backend === 'webgpu') {
     // Enable multi-threading if supported
     if (typeof SharedArrayBuffer !== 'undefined') {
-      ort.env.wasm.numThreads = numThreads || navigator.hardwareConcurrency || 4;
+      ort.env.wasm.numThreads = numThreads || (typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : 4) || 4;
       ort.env.wasm.simd = true;
       console.log(`[Parakeet.js] WASM configured with ${ort.env.wasm.numThreads} threads, SIMD enabled`);
     } else {
@@ -91,7 +91,7 @@ export function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
 
   if (backend === 'webgpu') {
     // Check WebGPU support properly
-    const webgpuSupported = 'gpu' in navigator;
+    const webgpuSupported = typeof navigator !== 'undefined' && 'gpu' in navigator;
     console.log(`[Parakeet.js] WebGPU supported: ${webgpuSupported}`);
 
     if (webgpuSupported) {


### PR DESCRIPTION
initOrt crashes in Node.js (CI) because navigator is undefined. Add typeof guards on both navigator.hardwareConcurrency and 'gpu' in navigator.

## Summary by Sourcery

Bug Fixes:
- Avoid crashes in initOrt when running under Node.js by handling undefined navigator before accessing hardwareConcurrency or gpu properties.