### PR TITLE
Clarify tensor disposal comment on blank token emission

### DIFF
--- a/src/parakeet.js
+++ b/src/parakeet.js
@@ -909,7 +909,7 @@ export class ParakeetModel {
         if (returnConfidences) tokenConfs.push(confVal);
         emittedTokens += 1;
       } else {
-        // Blank token: newState is unused, free its tensors (keep current decoderState)
+        // Blank token: free the new state tensors (keep current decoderState)
         this._disposeDecoderState(newState, decoderState);
       }
 


### PR DESCRIPTION
🧹 [code health improvement description]
🎯 **What:** Rewrote the code comment in `src/parakeet.js` explaining tensor disposal logic for blank tokens, changing "newState is unused" to "free the new state tensors".
💡 **Why:** A comment explicitly declaring a variable as "unused" when it is actually being utilized for essential resource cleanup (passed to `this._disposeDecoderState`) is misleading and frequently triggers false-positives in code scanners or static analysis tools. The updated comment accurately reflects that the variable's tensors are being safely freed without falsely labeling the variable itself as unused.
✅ **Verification:** Verified that `npm run test` executes perfectly with no newly introduced failures or regressions.
✨ **Result:** Enhanced the codebase by removing a potential source of code health noise and improving documentation clarity while strictly preserving existing tensor management behavior.

---
*PR created automatically by Jules for task [8264978234621761824](https://jules.google.com/task/8264978234621761824) started by @ysdede*

## Summary by Sourcery

Chores:
- Update an internal code comment to correctly describe freeing tensors for unused decoder state on blank token emission.