### PR TITLE
Add edge case tests for validateAudio

### DIFF
--- a/src/long_audio.js
+++ b/src/long_audio.js
@@ -456,6 +456,7 @@ async function runAutoSentenceWindowing({
  * @param {number} [opts.timeOffset=0]
  * @returns {Promise<{text: string, chunks?: Array<{ text: string, timestamp: [number, number] }>, words?: Array<{ text: string, start_time: number, end_time: number, confidence?: number }>}>}
  */
+export { validateAudio };
 export async function transcribeLongAudioWithChunks(model, audio, sampleRate = 16000, opts = {}) {
   validateAudio(audio);
   if (typeof sampleRate !== 'number' || !Number.isFinite(sampleRate) || sampleRate <= 0) {

--- a/tests/long_audio_chunking.test.mjs
+++ b/tests/long_audio_chunking.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ParakeetModel } from '../src/parakeet.js';
-import { transcribeLongAudioWithChunks } from '../src/long_audio.js';
+import { transcribeLongAudioWithChunks, validateAudio } from '../src/long_audio.js';
 
 describe('long-audio chunking helpers', () => {
   it('returns a simple text result when timestamps are not requested', async () => {
@@ -502,5 +502,38 @@ describe('long-audio chunking helpers', () => {
       { text: 'In the next chapter we will stroll further afield.', timestamp: [18.0, 22.0] },
       { text: 'End of chapter four.', timestamp: [22.8, 23.9] },
     ]);
+  });
+});
+
+describe('validateAudio', () => {
+  it('throws TypeError for invalid types', () => {
+    const invalidInputs = [
+      [],
+      [1, 2, 3],
+      new Uint8Array([1, 2, 3]),
+      'string',
+      null,
+      undefined,
+      {},
+    ];
+    for (const input of invalidInputs) {
+      expect(() => validateAudio(input)).toThrow(TypeError);
+    }
+  });
+
+  it('throws Error if audio contains non-finite values', () => {
+    expect(() => validateAudio(Float32Array.from([1, NaN, 3]))).toThrow(/finite audio samples/);
+    expect(() => validateAudio(Float64Array.from([1, Infinity, 3]))).toThrow(/finite audio samples/);
+    expect(() => validateAudio(Float32Array.from([-Infinity]))).toThrow(/finite audio samples/);
+  });
+
+  it('passes for empty typed arrays', () => {
+    expect(() => validateAudio(new Float32Array(0))).not.toThrow();
+    expect(() => validateAudio(new Float64Array(0))).not.toThrow();
+  });
+
+  it('passes for valid finite typed arrays', () => {
+    expect(() => validateAudio(Float32Array.from([1.5, -2.5, 0]))).not.toThrow();
+    expect(() => validateAudio(Float64Array.from([1.5, -2.5, 0]))).not.toThrow();
   });
 });


### PR DESCRIPTION
**What:** Missing edge case tests for `validateAudio`. 
**Coverage:** Tests for type validation (TypeError for Arrays, strings, null), finite values (Error for NaN and Infinity), happy path for valid Float32Array and Float64Array, and empty arrays. 
**Result:** Increased test coverage and confidence in `validateAudio` edge cases.

---
*PR created automatically by Jules for task [8709087404552855067](https://jules.google.com/task/8709087404552855067) started by @ysdede*

## Summary by Sourcery

Add edge case coverage for audio validation and expose the validateAudio helper for external use.

Enhancements:
- Export validateAudio from the long audio module so it can be used and tested externally.

Tests:
- Add tests verifying validateAudio rejects invalid input types such as arrays, strings, null, undefined, and plain objects.
- Add tests ensuring validateAudio throws when audio buffers contain non-finite values like NaN or Infinity.
- Add tests confirming validateAudio accepts empty typed arrays and finite Float32Array/Float64Array inputs.