### PR TITLE
Add error test for validateRequestedFp16Component

### DIFF
--- a/tests/hub-quantization.test.mjs
+++ b/tests/hub-quantization.test.mjs
@@ -325,4 +325,27 @@ describe('getParakeetModel quantization resolution (strict mode)', () => {
     expect(calls.some((x) => x.includes(`/api/models/${repoId}/tree/feat%2Ffp16-canonical-v2`))).toBe(true);
     expect(calls.some((x) => x.includes('/resolve/feat%2Ffp16-canonical-v2/encoder-model.fp16.onnx'))).toBe(true);
   });
+
+  it('throws explicit error when FP16 is missing and no FP32 fallback exists', async () => {
+    const repoId = 'test/repo-fp16-missing-entirely';
+    const { calls } = installFetchMock({
+      repoId,
+      siblings: [
+        'decoder_joint-model.fp16.onnx',
+        'vocab.txt',
+      ],
+    });
+
+    await expect(
+      getParakeetModel(repoId, {
+        backend: 'webgpu-hybrid',
+        encoderQuant: 'fp16',
+        decoderQuant: 'fp16',
+        preprocessorBackend: 'js',
+      })
+    ).rejects.toThrow(/Missing encoder model in test\/repo-fp16-missing-entirely: requested encoder-model\.fp16\.onnx\./i);
+
+    // Error is preflight, before resolve downloads.
+    expect(calls.some((x) => x.includes('/resolve/'))).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error test case for `validateRequestedFp16Component` in `src/hub.js`.

📊 **Coverage:** Specifically covers the condition where an FP16 file is missing and no FP32 fallback is found, which triggers the error message: `[Hub] Missing ${component.name} model in ${repoId}: requested ${fp16Name}.`

✨ **Result:** Increased test coverage for model quantization resolution error handling and strictly validates the fallback error message.

---
*PR created automatically by Jules for task [17034717363924255224](https://jules.google.com/task/17034717363924255224) started by @ysdede*

## Summary by Sourcery

Tests:
- Add a test ensuring an explicit error is thrown when the FP16 encoder model is absent and no FP32 fallback exists, and that no resolve requests are made in this preflight failure case.